### PR TITLE
Fix - fix volume rotation scale

### DIFF
--- a/SpacialMoodBoard/Sources/Helpers/Entity/Environment/Indoor/RoomEntityBuilder.swift
+++ b/SpacialMoodBoard/Sources/Helpers/Entity/Environment/Indoor/RoomEntityBuilder.swift
@@ -14,7 +14,6 @@ struct RoomEntityBuilder {
 
     // MARK: - Constants
 
-    private static let scaleFactor: Float = 15
     private static let floorThickness: Float = 0.01
 
     // MARK: - Initialization
@@ -48,9 +47,9 @@ struct RoomEntityBuilder {
     > {
         let dimensions = groundSize.dimensions
         return SIMD3<Float>(
-            Float(dimensions.x) / Self.scaleFactor,
-            Float(dimensions.y) / Self.scaleFactor,
-            Float(dimensions.z) / Self.scaleFactor
+            Float(dimensions.x),
+            Float(dimensions.y),
+            Float(dimensions.z)
         )
     }
 

--- a/SpacialMoodBoard/Sources/Models/Scene/SceneConf.swift
+++ b/SpacialMoodBoard/Sources/Models/Scene/SceneConf.swift
@@ -7,6 +7,7 @@ var enableGestures: Bool = true
 var enableAttachments: Bool = true
 var alignToWindowBottom: Bool = false
 var scale: Float = 1.0
+var volumeSize: Float? = nil  // Volume 윈도우 크기 (nil이면 자동 scale 미적용)
 
 static let immersive = SceneConfig(
     enableGestures: true,
@@ -17,7 +18,8 @@ static let volume = SceneConfig(
     showRotationButton: true,
     enableGestures: true,
     enableAttachments: true,
-    alignToWindowBottom: true
+    alignToWindowBottom: true,
+    volumeSize: 1.5  // App에서 정의된 Volume 윈도우 크기
 )
 
 static let minimap = SceneConfig(

--- a/SpacialMoodBoard/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
+++ b/SpacialMoodBoard/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
@@ -48,7 +48,7 @@ struct SceneRealityView: View {
     }
     
     // MARK: - Setup Scene
-    
+
     private func setupScene(content: RealityViewContent) async {
         guard let room = viewModel.getRoomEntity(
             for: appModel.selectedProject,
@@ -56,21 +56,37 @@ struct SceneRealityView: View {
         ) else {
             return
         }
-        
-        // 스케일 적용 (미니맵용)
-        room.scale = [config.scale, config.scale, config.scale]
-        
-        content.add(room)
-        
-        // Volume 전용: 위치 조정
-        if config.alignToWindowBottom {
-            viewModel.alignRoomToWindowBottom(room: room)
-        }
 
-        // Immersive 전용: RealityKit Content
-        if config.alignToWindowBottom == false {  // immersive 또는 minimap
-            if let immersiveContent = try? await Entity(named: "ImmersiveScene", in: RealityKitContent.realityKitContentBundle) {
-                room.addChild(immersiveContent)
+        if let volumeSize = config.volumeSize {
+            // Volume 모드: 자동 scale 계산 및 content 직접 추가
+            // 최종 크기를 0.6m로 고정 (RealityKit volumetric window 렌더링 보장)
+            let roomDimensions = viewModel.spacialEnvironment.groundSize.dimensions
+            let roomWidth = Float(roomDimensions.x)
+            let roomDepth = Float(roomDimensions.z)
+            let roomHeight = Float(roomDimensions.y)
+
+            let maxDimension = max(roomWidth, roomDepth, roomHeight)
+            let autoScale = 0.6 / maxDimension
+
+            room.scale = [autoScale, autoScale, autoScale]
+            content.add(room)
+
+            // Floor 하단 정렬
+            viewModel.alignRoomToWindowBottom(room: room, windowHeight: volumeSize)
+        } else {
+            // Immersive/Minimap 모드: 기존 방식
+            room.scale = [config.scale, config.scale, config.scale]
+            content.add(room)
+
+            if config.alignToWindowBottom {
+                viewModel.alignRoomToWindowBottom(room: room)
+            }
+
+            // Immersive 전용: RealityKit Content
+            if config.alignToWindowBottom == false {  // immersive 또는 minimap
+                if let immersiveContent = try? await Entity(named: "ImmersiveScene", in: RealityKitContent.realityKitContentBundle) {
+                    room.addChild(immersiveContent)
+                }
             }
         }
     }

--- a/SpacialMoodBoard/Sources/Presentations/SceneRealityView/View/VolumeScene/VolumeSceneView.swift
+++ b/SpacialMoodBoard/Sources/Presentations/SceneRealityView/View/VolumeScene/VolumeSceneView.swift
@@ -14,6 +14,9 @@ struct VolumeSceneView: View {
       config: .volume
     )
     .preferredWindowClippingMargins(.all, 400)
+    .onAppear {
+      viewModel.resetRotation()
+    }
     .onDisappear {
       viewModel.reset()
     }

--- a/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+VolumeFeatures.swift
+++ b/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+VolumeFeatures.swift
@@ -19,7 +19,7 @@ extension SceneViewModel {
   }
   
   func resetRotation() {
-    rotationAngle = .pi / 4
+    rotationAngle = 0
 
     guard let projectId = appModel.selectedProject?.id,
           let roomEntity = roomEntities[projectId] else {

--- a/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+VolumeFeatures.swift
+++ b/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+VolumeFeatures.swift
@@ -30,10 +30,10 @@ extension SceneViewModel {
   }
 
   // MARK: - 위치 조정
-  
+
   func alignRoomToWindowBottom(
     room: Entity,
-    windowHeight: Float = 1.0,
+    windowHeight: Float = 1.5,
     padding: Float = 0.02
   ) {
     let bounds = room.visualBounds(relativeTo: room)

--- a/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel.swift
+++ b/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel.swift
@@ -33,7 +33,7 @@ final class SceneViewModel {
     var selectedEntity: ModelEntity?
     
     // 회전 각도 (Volume용)
-    var rotationAngle: Float = .pi / 4
+    var rotationAngle: Float = 0
 
     // SceneObjects (computed property)
     var sceneObjects: [SceneObject] {
@@ -70,11 +70,11 @@ final class SceneViewModel {
     
     
     // MARK: - Cleanup
-    
+
     func reset() {
         entityMap.removeAll()
         selectedEntity = nil
         roomEntities.removeAll()
-        rotationAngle = .pi / 4
+        rotationAngle = 0
     }
 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->

  Volume 윈도우의 Entity 생성 방식 및 초기 각도,크기 변경.

  주요 변경사항

  1. Entity 생성 방식 변경
    - RoomEntityBuilder에서 scaleFactor=15 제거
    - Entity를 원본 크기(Medium: 10x10m)로 생성하도록 변경
    - Immersive 모드에서 적절한 크기로 표시되도록 개선
  2. Volume 렌더링 최적화
    - 최종 크기를 0.6m로 고정
    - content.add(room) 방식으로 직접 추가하여 updateScene() 호환성 확보
  3. Volume 초기 Rotation 개선
    - Volume 열릴 때 항상 0도로 시작하도록 변경
    - VolumeSceneView에 onAppear 추가하여 자동 리셋 구현
    - 초기값 기존 45도 -> 0도로 변경
  4. SceneConfig 개선
    - volumeSize 필드 추가로 Volume 전용 설정 명확화

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->

Volume 크기 모든 GroundSize에서 0.6m로 통일
  - Volume 최종 크기(0.6m)가 너무 작지 않은지 확인 필요. 현재 0.6인데, 1.0보다 큰 크기로는 생성 불가.

Immersive 모드에서 Entity 크기(10m)가 적절한지 실제 디바이스에서 테스트 후 크기 조정 필요.