### PR TITLE
feat: 삭제 클릭시 삭제 popup 형성 및 기능 구현

### DIFF
--- a/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
+++ b/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
@@ -5,7 +5,7 @@ import SwiftUI
 // MARK: - Attachment Management
 
 extension SceneViewModel {
-  
+    
     func updateAttachment(
         onDuplicate: @escaping () -> Void,
         onCrop: @escaping () -> Void,
@@ -13,24 +13,43 @@ extension SceneViewModel {
     ) {
         // 기존 attachment 모두 제거
         removeAllAttachments()
-    
+        
         // 선택된 Entity에 attachment 추가
         guard let entity = selectedEntity,
-                    let objectId = UUID(uuidString: entity.name) else {
+              let objectId = UUID(uuidString: entity.name) else {
             return
         }
-    
-        addAttachment(
+        
+        addEditBarAttachment(
             to: entity,
             objectId: objectId,
             onDuplicate: onDuplicate,
             onCrop: onCrop,
-            onDelete: onDelete
+            onDelete: {
+                // EditBar 제거 후 DeleteAttachment 표시
+                self.removeAttachment(from: entity, named: "objectAttachment")
+                self.addDeleteAttachment(
+                    to: entity,
+                    objectId: objectId,
+                    onDelete: onDelete,
+                    onCancel: {
+                        // DeleteAttachment 제거 후 EditBar 다시 표시
+                        self.removeAttachment(from: entity, named: "deleteAttachment")
+                        self.addEditBarAttachment(
+                            to: entity,
+                            objectId: objectId,
+                            onDuplicate: onDuplicate,
+                            onCrop: onCrop,
+                            onDelete: onDelete // 재귀적 로직
+                        )
+                    }
+                )
+            }
         )
     }
-  
+    
     // MARK: - Private Helpers
-  
+    
     private func removeAllAttachments() {
         for entity in entityMap.values {
             entity.children
@@ -38,8 +57,14 @@ extension SceneViewModel {
                 .forEach { $0.removeFromParent() }
         }
     }
-  
-    private func addAttachment(
+    
+    private func removeAttachment(from entity: ModelEntity, named attachmentName: String) {
+        entity.children
+            .filter { $0.name == attachmentName }
+            .forEach { $0.removeFromParent() }
+    }
+    
+    private func addEditBarAttachment(
         to entity: ModelEntity,
         objectId: UUID,
         onDuplicate: @escaping () -> Void,
@@ -48,7 +73,7 @@ extension SceneViewModel {
     ) {
         let objectAttachment = Entity()
         objectAttachment.name = "objectAttachment"
-    
+        
         // ViewAttachmentComponent 생성
         let attachment = ViewAttachmentComponent(
             rootView: EditBarAttachment(
@@ -60,23 +85,50 @@ extension SceneViewModel {
         )
         objectAttachment.components.set(attachment)
         entity.addChild(objectAttachment)
-    
+        
         // Attachment 위치 설정
         topPositionAttachment(objectAttachment, relativeTo: entity)
+    }
+    
+    private func addDeleteAttachment(
+        to entity: ModelEntity,
+        objectId: UUID,
+        onDelete: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        let deleteAttachment = Entity()
+        deleteAttachment.name = "deleteAttachment"
+        
+        // Asset 이름 가져오기
+        let assetName = sceneObjects.first(where: { $0.id == objectId })?.assetId ?? "Unknown"
+        
+        // ViewAttachmentComponent 생성
+        let attachment = ViewAttachmentComponent(
+            rootView: DeleteAttachment(
+                assetName: assetName,
+                onDelete: onDelete,
+                onCancel: onCancel
+            )
+        )
+        deleteAttachment.components.set(attachment)
+        entity.addChild(deleteAttachment)
+        
+        // Attachment 위치 설정 (중앙 앞쪽)
+        centerPositionAttachment(deleteAttachment, relativeTo: entity)
     }
     
     // 상단 위치로 Attachment 설정(EditBarAttachment 위치)
     private func topPositionAttachment(_ attachment: Entity, relativeTo parent: Entity) {
         let objectBounds = parent.visualBounds(relativeTo: parent)
         let attachmentBounds = attachment.visualBounds(relativeTo: attachment)
-    
+        
         let yOffset = objectBounds.max.y + attachmentBounds.max.y / 2 + 0.05
         attachment.transform = Transform(translation: SIMD3<Float>(0, yOffset, 0))
     }
-
+    
     private func centerPositionAttachment(_ attachment: Entity, relativeTo parent: Entity) {
         // let objectBounds = parent.visualBounds(relativeTo: parent)
-        let attachmentBounds = attachment.visualBounds(relativeTo: attachment)
+        //        let attachmentBounds = attachment.visualBounds(relativeTo: attachment)
         attachment.transform = Transform(translation: SIMD3<Float>(0, 0, 0.1))
     }
 }


### PR DESCRIPTION
## 🔍 PR Content
삭제 클릭시 삭제 popup 형성 및 기능 구현.
***실수로 dev에 1개의 commit을 push 한상태로 시작 
	->  관련내용: 
			feat: 이미지 중간에 위치시킬 수 있는 함수 생성 및 기존 attachment 위치 조절 함수 이름 변경(단일 attachment 위치에서 두개가 
					되었기 때문)***

참고사항: 
- 개인적으로 이 팝업이 없어도 된다고 생각됨. 디자이너와 한번 더 상의후 이 pr을 머지할지 결정 예정
- 이미지 이름을 팝업에 띄웠었는데, 이미지 이름을 랜덤하게 길게 생성중. 따라서 이 부분 수정 후 머지 결정 필요


## 📸 Screenshot
<img width="338" height="269" alt="image" src="https://github.com/user-attachments/assets/593de795-b74e-4577-b8d4-d64ddee14fb0" />

## 📍 PR Point 
현재 updateAttachment 함수에서 onDelete를 재귀적으로 구현. (한개의 기능을 위해서 추가적인 변수를 만들고 싶지 않아서.)
가독성이 떨어지는데 괜찮은지, 그냥 변수를 하나 더 추가한게 좋을지 의견을 듣고 싶습니다.
```
            onDelete: {
                // EditBar 제거 후 DeleteAttachment 표시
                self.removeAttachment(from: entity, named: "objectAttachment")
                self.addDeleteAttachment(
                    to: entity,
                    objectId: objectId,
                    onDelete: onDelete,
                    onCancel: {
                        // DeleteAttachment 제거 후 EditBar 다시 표시
                        self.removeAttachment(from: entity, named: "deleteAttachment")
                        self.addEditBarAttachment(
                            to: entity,
                            objectId: objectId,
                            onDuplicate: onDuplicate,
                            onCrop: onCrop,
                            onDelete: onDelete // 재귀적 로직
                        )
                    }
                )
            }

```