### PR TITLE
Feat - image attachment 에 빌보드 및 사이즈 재조정 로직 추가

### DIFF
--- a/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
+++ b/SpacialMoodBoard/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
@@ -85,8 +85,6 @@ extension SceneViewModel {
     }
 
     private func centerPositionAttachment(_ attachment: Entity, relativeTo parent: Entity) {
-        // let objectBounds = parent.visualBounds(relativeTo: parent)
-        let attachmentBounds = attachment.visualBounds(relativeTo: attachment)
-        attachment.transform = Transform(translation: SIMD3<Float>(0, 0, 0.1))
+        attachment.position = SIMD3<Float>(0, 0, 0.1)
     }
 }


### PR DESCRIPTION
## 🔍 PR Content
image attachment에 빌보드 및 사이즈 관련 로직 추가.
현재 이미지와 attachment 사이의 거리, 사이즈 변화시 불연속적으로 사이즈 유지됨. -> 향후 수정 예정

## 📸 Screenshot
<img width="398" height="391" alt="image" src="https://github.com/user-attachments/assets/46a3bcd1-7670-4b36-b2ab-c9030efd9d8a" />
