### PR TITLE
Feat - 이미지 피사체분리 drag시 border 테스트

### DIFF
--- a/SpacialMoodBoard/Sources/Presentations/Library/ImageEditor/View/ImageEditorView.swift
+++ b/SpacialMoodBoard/Sources/Presentations/Library/ImageEditor/View/ImageEditorView.swift
@@ -119,8 +119,6 @@ fileprivate struct EditorToolbarView: View {
 
     var body: some View {
         HStack(alignment: .center) {
-            IconCircleButton(systemName: "chevron.left", action: dismiss)
-
             HiddenOrSpace(show: !viewModel.showSidebar, size: 44) {
                 IconCircleButton(systemName: "square.split.2x1") {
                     withAnimation(.easeInOut(duration: 0.22)) { viewModel.showSidebar = true }

--- a/SpacialMoodBoard/Sources/Presentations/Library/ImageEditor/ViewModel/ImageEditorViewModel.swift
+++ b/SpacialMoodBoard/Sources/Presentations/Library/ImageEditor/ViewModel/ImageEditorViewModel.swift
@@ -127,7 +127,7 @@ final class ImageEditorViewModel {
         return handled
     }
     
-    /// 편집 중인 이미지를 현재 프로젝트의 `/images` 폴더에 JPEG로 저장하고, 저장된 파일의 URL을 반환합니다.
+    /// 편집 중인 이미지를 현재 프로젝트의 `/images` 폴더에 png로 저장하고, 저장된 파일의 URL을 반환합니다.
     /// - Parameter image: 저장할 `UIImage`.
     /// - Returns: 저장에 성공하면 `Documents/projects/<projectName>/images/<uuid>.jpg`의 파일 URL, 실패 시 `nil`
     private func saveToProject(image: UIImage) async -> URL? {


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->

- [x] 이미지 피사체분리 drag시 border 테스트
-> 안된다는 거 확인해서 디자인 수정 요청

**안되는 이유:**

```
1. Subject Lift는 ImageAnalysisInteraction(또는 시스템 DnD) 파이프라인 안에서 비공개(offscreen)로 생성된 프리뷰 띠움
- 그 프리뷰는 UIKit/SwiftUI 계층의 자식 뷰가 아니라 시스템이 잡고 있는 스냅샷이라, overlay, border, CALayer 변경 같은 후처리를 붙일 훅이 없음

2. 경계가 “기하(Geometry)”가 아님
- 피사체 분리는 알파 마스크가 있는 비트맵일 뿐, 윤곽선(Path)나 메시가 아님
- 테두리를 그리려면 외곽선을 벡터로 갖고 있거나(Stroke), 혹은 셰이더/마스크 연산으로 “두께”를 만들어야 하는데, 시스템 프리뷰는 그걸 노출하지 않음
```

- [x] 이미지 저장하기 버튼 하이파이 UI 디자인 입힘
