### PR TITLE
Fix - 볼륨 닫을때 프로젝트 nil로 변경하는 코드 삭제(이멀시브 진입할때까지 프로젝트가 nil이 되버림)

### DIFF
--- a/SpacialMoodBoard/App/SpacialMoodBoardApp.swift
+++ b/SpacialMoodBoard/App/SpacialMoodBoardApp.swift
@@ -69,9 +69,6 @@ struct SpacialMoodBoardApp: App {
                 viewModel: sceneViewModel
             )
             .environment(appModel)
-            .onDisappear {
-                appModel.selectedProject = nil
-            }
         }
         .windowStyle(.volumetric)
         .defaultSize(width: 1.5, height: 1.5, depth: 1.5, in: .meters)


### PR DESCRIPTION
## 🔍 PR Content
- 볼륨 삭제시 프로젝트로 돌아가게 플로우 제작. -> 볼륨이 삭제될때 selectedProject = nil로 함으로서
- 의도치 않게 이멀시브로 넘어갈때 프로젝트가 nil이 되면서 사라지게 됨

향후 이부분 수정 필요
