### PR TITLE
fix: overlay를 통해 text를 입력 받았던 것 help를 통해 나오게 변경

### DIFF
--- a/SpacialMoodBoard/Sources/Common/UIComponent/Button/ToolBarToggleButton.swift
+++ b/SpacialMoodBoard/Sources/Common/UIComponent/Button/ToolBarToggleButton.swift
@@ -5,7 +5,6 @@ struct ToolBarToggleButton: View {
     private let action: () -> Void
     private var isSelected: Bool
     
-    @State private var isHovering = false
     @Environment(\.colorScheme) private var scheme
     
     init(type: ToolBarToggleButtonEnum,
@@ -27,8 +26,6 @@ struct ToolBarToggleButton: View {
                 .clipShape(Circle())
         }
         .buttonStyle(.plain)
-        .onHover { isHovering = $0 }
-        .animation(.easeInOut(duration: 0.18), value: isHovering)
         .animation(.easeInOut(duration: 0.18), value: isSelected)
         .accessibilityLabel(type.name)
         .accessibilityAddTraits(isSelected ? .isSelected : [])


### PR DESCRIPTION
## 🔍 PR Content
Attachment ToolBar hovering시 이름 뜨게 설정
기존 overlay로 직접 구현했던 코드 .help를 통해서 구현

## 📸 Screenshot
<img width="330" height="215" alt="image" src="https://github.com/user-attachments/assets/89dcde20-ffe5-4d5c-85df-2ee36a5e76a8" />

## 📍 PR Point 
하이파이와 약간의 색 차이가 존재하긴하는데 거의 동일하다고 느껴집니다.
혹시 .help가 아닌 overlay를 통해 구현하고자 했던 이유가 있는지 궁금합니다.
