### PR TITLE
[Feat] -  사운드 관련 2차 QA 반영

### DIFF
--- a/Glayer/Sources/Common/Enum/Toast/ToastMessage.swift
+++ b/Glayer/Sources/Common/Enum/Toast/ToastMessage.swift
@@ -5,36 +5,50 @@
 //  Created by jeongminji on 11/8/25.
 //
 
+import SwiftUI
+
 enum ToastMessage {
     case addToLibrary
     case addToLibraryFail
     case loadingError
     case loadingImageEdit
     case loadingAssets
+    case addToVolume
     
     var title: String {
         switch self {
         case .addToLibrary:
-            return "에셋 추가 완료"
+            return String(localized: "toast.addToLibrary.title")
         case .addToLibraryFail:
-            return "에셋 추가 실패"
+            return String(localized: "toast.addToLibraryFail.title")
         case .loadingError:
-            return "불러오기 오류"
+            return String(localized: "toast.loadingError.title")
         case .loadingImageEdit:
-            return "이미지 편집 준비 중"
+            return String(localized: "toast.loadingImageEdit.title")
         case .loadingAssets:
-            return "에셋 불러오는 중"
+            return String(localized: "toast.loadingAssets.title")
+        case .addToVolume:
+            return String(localized: "toast.addToVolume.title")
+        }
+    }
+    
+    var titleFont: Font {
+        switch self {
+        case .addToVolume:
+            return .system(size: 19, weight: .medium)
+        default:
+            return .system(size: 19, weight: .bold)
         }
     }
     
     var subtitle: String? {
         switch self {
         case .addToLibrary:
-            return "에셋이 라이브러리에 저장되었습니다."
+            return String(localized: "toast.addToLibrary.subtitle")
         case .addToLibraryFail:
-            return "라이브러리 저장에 실패했습니다."
+            return String(localized: "toast.addToLibraryFail.subtitle")
         case .loadingError:
-            return "에셋을 불러오는데 실패했습니다."
+            return String(localized: "toast.loadingError.subtitle")
         default:
             return nil
         }
@@ -58,21 +72,54 @@ enum ToastMessage {
         }
     }
     
+    var image: Image? {
+        switch self {
+        case .addToVolume:
+            return Image(systemName: "checkmark.circle")
+        default:
+            return nil
+        }
+    }
+    
     var position: ToastPosition {
         switch self {
+        case .addToVolume:
+            return .bottom
         default:
-                .center
+            return .center
         }
     }
     
     var dismissMode: ToastDismissMode {
         switch self {
-        case .addToLibrary, .addToLibraryFail:
-            return .auto(duration: 1.3)
         case .loadingError:
             return .manual
         case .loadingImageEdit, .loadingAssets:
             return .external()
+        default:
+            return .auto(duration: 1.3)
+        }
+    }
+    
+    var textPadding: (h: CGFloat, v: CGFloat) {
+        switch self {
+        case .loadingAssets:
+            return (16, 8)
+        case .addToVolume:
+            return (0,  0)
+        default:
+            return (4, 8)
+        }
+    }
+    
+    var bodyPadding: (h: CGFloat, v: CGFloat) {
+        switch self {
+        case .loadingAssets:
+            return (24, 24)
+        case .addToVolume:
+            return (24,  20)
+        default:
+            return (25, 25)
         }
     }
 }

--- a/Glayer/Sources/Common/Modifier/ToastPresenter.swift
+++ b/Glayer/Sources/Common/Modifier/ToastPresenter.swift
@@ -10,17 +10,14 @@ import SwiftUI
 private struct ToastPresenter: ViewModifier {
     @Binding private var isPresented: Bool
     private let message: ToastMessage
-    private let dismissWhen: (() -> Bool)?
     
     /// init
     /// - Parameters:
     ///   - isPresented: 토스트 표시 여부를 제어하는 바인딩 값. `true`일 때 토스트가 화면에 나타남
     ///   - message: 표시할 토스트 메시지(`ToastMessage` 열거형). 텍스트, 위치, 사운드, 해제 모드 등의 정보를 포함
-    ///   - dismissWhen: `.external` 모드일 때 토스트를 닫을지 여부를 반환하는 조건 클로저(옵셔널)
-    init(isPresented: Binding<Bool>, message: ToastMessage, dismissWhen: (() -> Bool)? = nil) {
+    init(isPresented: Binding<Bool>, message: ToastMessage) {
         self._isPresented = isPresented
         self.message = message
-        self.dismissWhen = dismissWhen
     }
     
     func body(content: Content) -> some View {
@@ -41,33 +38,12 @@ private struct ToastPresenter: ViewModifier {
                         }
                     }
                     
-                    let _: ToastDismissMode = {
-                        switch message.dismissMode {
-                        case .external:
-                            return .external(shouldDismiss: dismissWhen)
-                        default:
-                            return message.dismissMode
-                        }
-                    }()
-                    
                     switch message.dismissMode {
                     case let .auto(duration):
                         DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
                             withAnimation(.easeInOut(duration: 0.18)) { isPresented = false }
                         }
-                    case let .external(shouldDismiss):
-                        if let shouldDismiss {
-                            Task { @MainActor in
-                                while isPresented {
-                                    try? await Task.sleep(for: .milliseconds(300))
-                                    if shouldDismiss() {
-                                        withAnimation(.easeInOut(duration: 0.18)) { isPresented = false }
-                                        break
-                                    }
-                                }
-                            }
-                        }
-                    case .manual:
+                    default:
                         break
                     }
                 }
@@ -95,13 +71,11 @@ extension View {
     ///   - message: ToastMessage 열거형 (title, subtitle, dismissMode, position, sfx 모두 포함)
     func toast(
         isPresented: Binding<Bool>,
-        message: ToastMessage,
-        dismissWhen: (() -> Bool)? = nil
+        message: ToastMessage
     ) -> some View {
         modifier(ToastPresenter(
             isPresented: isPresented,
-            message: message,
-            dismissWhen: dismissWhen)
+            message: message)
         )
     }
 }

--- a/Glayer/Sources/Common/UIComponent/Button/CircleFillButton.swift
+++ b/Glayer/Sources/Common/UIComponent/Button/CircleFillButton.swift
@@ -28,11 +28,13 @@ struct CircleFillButton: View {
     
     var body: some View {
         Button(action: action) {
-            Image(systemName: type.systemName)
-                .font(type.font)
+            VStack {
+                Image(systemName: type.systemName)
+                    .font(type.font)
+            }
+            .frame(width: type.size, height: type.size)
         }
         .circleButtonStyle(type.buttonStyle)
-        .frame(width: type.size, height: type.size)
         .clipShape(Circle())
     }
 }

--- a/Glayer/Sources/Common/UIComponent/CapsuleVolumeSlider.swift
+++ b/Glayer/Sources/Common/UIComponent/CapsuleVolumeSlider.swift
@@ -77,6 +77,11 @@ struct CapsuleVolumeSlider: View {
             .padding(.horizontal, 10)
             .contentShape(Capsule())
             .frame(maxHeight: .infinity)
+            .onChange(of: value) { _, new in
+                if !isDragging {
+                    internalValue = new
+                }
+            }
             .highPriorityGesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { g in

--- a/Glayer/Sources/Common/UIComponent/ToastView.swift
+++ b/Glayer/Sources/Common/UIComponent/ToastView.swift
@@ -17,7 +17,7 @@ struct ToastView: View {
     
     var body: some View {
         VStack(alignment: .center, spacing: 8) {
-            HStack(spacing: 24) {
+            HStack(spacing: message.image != nil ? 12 : 24) {
                 if let ani = message.animationName, message.animationName != nil {
                     LottieView {
                         LottieAnimation.named(ani, bundle: .main)
@@ -29,9 +29,13 @@ struct ToastView: View {
                     .frame(width: 28, height: 32)
                 }
                 
+                if let image = message.image, message.image != nil {
+                    image
+                }
+                
                 VStack(alignment: .center, spacing: 2) {
                     Text(message.title)
-                        .font(.system(size: 19, weight: .bold))
+                        .font(message.titleFont)
                         .foregroundStyle(.primary)
                     
                     if let sub = message.subtitle, !sub.isEmpty {
@@ -40,13 +44,13 @@ struct ToastView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                .padding(.horizontal, message.animationName != nil ? 16 : 4)
-                .padding(.vertical, 8)
+                .padding(.horizontal, message.textPadding.h)
+                .padding(.vertical, message.textPadding.v)
             }
             
             if case .manual = message.dismissMode {
                 Button(action: { dismissAction?() }) {
-                    Text(String(localized: "action.confirm"))
+                    Text("확인")
                         .font(.system(size: 17, weight: .semibold))
                         .padding(.horizontal, 99)
                         .padding(.vertical, 12)
@@ -56,8 +60,8 @@ struct ToastView: View {
                 .contentShape(Capsule())
             }
         }
-        .padding(.horizontal, message.animationName != nil ? 44 : 25)
-        .padding(.vertical, message.animationName != nil ? 24 : 25)
+        .padding(.horizontal, message.bodyPadding.h)
+        .padding(.vertical, message.bodyPadding.v)
         .glassBackgroundEffect(in: RoundedRectangle(cornerRadius: 32, style: .continuous))
         .accessibilityAddTraits(.isStaticText)
     }

--- a/Glayer/Sources/Helpers/Entity/Sound/SoundEntity.swift
+++ b/Glayer/Sources/Helpers/Entity/Sound/SoundEntity.swift
@@ -80,15 +80,14 @@ struct SoundEntity {
                 let controller = modelEntity.prepareAudio(res)
                 modelEntity.components.set(SoundControllerComponent(controller: controller))
                 
-                SceneAudioCoordinator.shared.register(entityId: sceneObject.id, controller: controller)
+                SceneAudioCoordinator.shared.register(
+                    entityId: sceneObject.id,
+                    controller: controller,
+                    shouldStartPlaying: audioAttrs.volume > 0
+                )
+                
                 let db = linearToDecibels(Double(audioAttrs.volume))
                 SceneAudioCoordinator.shared.setGain(db, for: sceneObject.id)
-                
-                if audioAttrs.volume > 0 {
-                    SceneAudioCoordinator.shared.play(sceneObject.id)
-                } else {
-                    SceneAudioCoordinator.shared.pause(sceneObject.id)
-                }
             } catch {
                 print("⚠️ SoundEntity.create: 오디오 로드 실패 - \(error)")
             }

--- a/Glayer/Sources/Helpers/SoundPlayer/SceneAudioCoordinator.swift
+++ b/Glayer/Sources/Helpers/SoundPlayer/SceneAudioCoordinator.swift
@@ -41,6 +41,11 @@ final class SceneAudioCoordinator {
     ///   - controller: 등록할 `AudioPlaybackController` 인스턴스
     func register(entityId: UUID, controller: AudioPlaybackController) {
         controllers[entityId] = WeakController(controller: controller)
+
+        if isGlobalMute {
+            controller.pause()
+            playing.remove(entityId)
+        }
     }
     
     /// 삭제된 엔티티의 컨트롤러를 등록 목록에서 제거
@@ -66,6 +71,10 @@ final class SceneAudioCoordinator {
     /// - Parameter id: 엔티티 UUID
     func play(_ id: UUID) {
         guard let c = controller(for: id) else { return }
+        guard !isGlobalMute else {
+            playing.remove(id)
+            return
+        }
         c.play()
         playing.insert(id)
     }

--- a/Glayer/Sources/Helpers/SoundPlayer/SceneAudioCoordinator.swift
+++ b/Glayer/Sources/Helpers/SoundPlayer/SceneAudioCoordinator.swift
@@ -26,9 +26,9 @@ final class SceneAudioCoordinator {
     private var playing: Set<UUID> = []
     
     private enum PauseScope {
-            case external    // 라이브러리(외부) 인터럽션
-            case globalMute  // 툴바 글로벌 음소거
-        }
+        case external    // 라이브러리(외부) 인터럽션
+        case globalMute  // 툴바 글로벌 음소거
+    }
     
     /// 정지 사유, “인터럽션 시작 시점에 재생 중이던 ID 집합”을 스택에 보관
     private var pauseStack: [(scope: PauseScope, snapshot: Set<UUID>)] = []
@@ -38,13 +38,19 @@ final class SceneAudioCoordinator {
     /// 새로운 SoundEntity를 등록하여 컨트롤러를 추적
     /// - Parameters:
     ///   - entityId: 엔티티의 고유 식별자(UUID)
-    ///   - controller: 등록할 `AudioPlaybackController` 인스턴스
-    func register(entityId: UUID, controller: AudioPlaybackController) {
+    ///   - controller: 등록할 `AudioPlaybackController`
+    ///   - shouldStartPlaying: 기본 재생 의도 (초기 볼륨 > 0 등)
+    func register(entityId: UUID, controller: AudioPlaybackController, shouldStartPlaying: Bool) {
         controllers[entityId] = WeakController(controller: controller)
-
+        
         if isGlobalMute {
             controller.pause()
-            playing.remove(entityId)
+            if shouldStartPlaying { appendToGlobalMuteSnapshot(entityId) }
+        } else {
+            if shouldStartPlaying {
+                controller.play()
+                playing.insert(entityId)
+            }
         }
     }
     
@@ -85,6 +91,11 @@ final class SceneAudioCoordinator {
         guard let c = controller(for: id) else { return }
         c.pause()
         playing.remove(id)
+        
+        if isGlobalMute, var top = pauseStack.last, top.scope == .globalMute {
+            top.snapshot.remove(id)
+            pauseStack[pauseStack.count - 1] = top
+        }
     }
     
     /// 특정 엔티티 정지(재생 위치 초기화 포함)
@@ -93,6 +104,11 @@ final class SceneAudioCoordinator {
         guard let c = controller(for: id) else { return }
         c.stop()
         playing.remove(id)
+        
+        if isGlobalMute, var top = pauseStack.last, top.scope == .globalMute {
+            top.snapshot.remove(id)
+            pauseStack[pauseStack.count - 1] = top
+        }
     }
     
     /// 특정 엔티티 볼륨(gain, dB)을 설정
@@ -190,6 +206,14 @@ extension SceneAudioCoordinator {
             isGlobalMute = false
             popPause(.globalMute)
         }
+    }
+    
+    /// 현재 글로벌 뮤트 스냅샷에 id를 추가 (뮤트 해제 시 자동 재생되도록)
+    /// - Parameter id: 추가할 사운드 오브젝트의 id
+    private func appendToGlobalMuteSnapshot(_ id: UUID) {
+        guard var top = pauseStack.last, top.scope == .globalMute else { return }
+        top.snapshot.insert(id)
+        pauseStack[pauseStack.count - 1] = top
     }
     
     // MARK: - Housekeeping

--- a/Glayer/Sources/Presentations/Library/LibraryList/ViewModel/LibraryViewModel.swift
+++ b/Glayer/Sources/Presentations/Library/LibraryList/ViewModel/LibraryViewModel.swift
@@ -45,13 +45,15 @@ final class LibraryViewModel {
             }
         }
     }
-
+    
     var showLoadErrorToast = false
+    var isPreparingImagesToast = false
+    var showAddedToast = false
+
     var showDropDock = false
     var showFileImporter = false
     var editorImages: [UIImage] = []
     var editorPreferredNames: [String?] = []
-    var isPreparingImages = false
     var showEditor = false
     
     // MARK: - Init
@@ -194,8 +196,8 @@ extension LibraryViewModel {
     ///   - kind: 임포트 대상 종류(.image / .sound). 보통 현재 탭 상태를 반영
     ///   - source: 임포트 소스(드래그드롭/포토피커/클립보드/파일URL)
     private func runImport(kind: AssetType, source: ImportRequest.Source) async {
-        isPreparingImages = true
-        defer { isPreparingImages = false }
+        isPreparingImagesToast = true
+        defer { isPreparingImagesToast = false }
         
         let request = ImportRequest(
             kind: kind,

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/EditBar/EditBarAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/EditBar/EditBarAttachment.swift
@@ -90,7 +90,7 @@ struct EditBarAttachment: View {
                         }
                     }
                 )
-                .frame(width: 100)
+                .frame(width: 120)
                 .frame(maxHeight: .infinity)
                 .hoverEffect()
                 .accessibilityLabel("Volume")

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/EditBar/EditBarAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/EditBar/EditBarAttachment.swift
@@ -9,6 +9,7 @@ struct EditBarAttachment: View {
     
     private let onDuplicate: (() -> Void)?
     private let onCrop: (() -> Void)?
+    private let onVolumeChanging: ((Double) -> Void)?
     private let onVolumeChange: ((Double) -> Void)?
     private let onDelete: () -> Void
     
@@ -31,6 +32,7 @@ struct EditBarAttachment: View {
         objectId: UUID,
         objectType: AssetType,
         initialVolume: Double = 1.0,
+        onVolumeChanging: ((Double) -> Void)? = nil,
         onVolumeChange: ((Double) -> Void)? = nil,
         onDuplicate: (() -> Void)? = nil,
         onCrop: (() -> Void)? = nil,
@@ -39,6 +41,7 @@ struct EditBarAttachment: View {
         self.objectId = objectId
         self.objectType = objectType
         self._volume = State(initialValue: min(max(initialVolume, 0.0), 1.0))
+        self.onVolumeChanging = onVolumeChanging
         self.onVolumeChange = onVolumeChange
         self.onDuplicate = onDuplicate
         self.onCrop = onCrop
@@ -54,10 +57,10 @@ struct EditBarAttachment: View {
             switch objectType {
             case .image:
                 // 크롭 버튼
-//                if let onCrop {
-//                    CircleFillButton(type: .crop, action: onCrop)
-//                        .accessibilityLabel("Crop")
-//                }
+                //                if let onCrop {
+                //                    CircleFillButton(type: .crop, action: onCrop)
+                //                        .accessibilityLabel("Crop")
+                //                }
                 // 복사 버튼
                 if let onDuplicate {
                     CircleFillButton(type: .duplicate, action: onDuplicate)
@@ -82,6 +85,7 @@ struct EditBarAttachment: View {
                             } else {
                                 isMuted = true
                             }
+                            onVolumeChanging?(newValue)
                         }
                     ),
                     onEditingChanged: { isEditing in
@@ -114,11 +118,13 @@ struct EditBarAttachment: View {
             let restore = max(lastNonZeroVolume, 0.1)
             volume = restore
             isMuted = false
+            onVolumeChanging?(restore)
             onVolumeChange?(restore)
         } else {
             lastNonZeroVolume = volume > 0 ? volume : lastNonZeroVolume
             volume = 0
             isMuted = true
+            onVolumeChanging?(0)
             onVolumeChange?(0)
         }
     }

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/ToolBar/ToolBarAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/ToolBar/ToolBarAttachment.swift
@@ -63,6 +63,9 @@ struct ToolBarAttachment: View {
                 switch await openImmersiveSpace(id: "ImmersiveScene") {
                 case .opened:
                     await appStateManager.openImmersive()
+                    if let paused = appStateManager.selectedScene?.userSpatialState.paused {
+                        SceneAudioCoordinator.shared.setGlobalMute(paused)
+                    }
                 case .userCancelled, .error:
                     print("⚠️ Immersive Space 열기 실패")
                 @unknown default:

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImmersiveFeatures.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImmersiveFeatures.swift
@@ -8,7 +8,12 @@ extension SceneViewModel {
     // MARK: - Add Image Object
     
     /// ImageEditor나 Library에서 호출 (anchor는 SceneRealityView에서 전달)
-    func addImageObject(from asset: Asset, rootEntity: Entity? = nil) {
+    @discardableResult
+    func addImageObject(from asset: Asset, rootEntity: Entity? = nil) throws -> SceneObject {
+        guard asset.type == .image else {
+            throw NSError(domain: "Scene", code: 1)
+        }
+        
         // Volume 모드와 Immersive 모드에 따라 다른 초기 위치 설정
         // Volume: window 중앙 (y=0.1m, z=-1.0m) - 1m 크기 volume 내에서 보이도록
         // Immersive: 사용자 눈높이 (y=1.5m, z=-2.0m) - 기존 동작 유지
@@ -32,11 +37,16 @@ extension SceneViewModel {
         // SceneViewModel+SceneObject의 addSceneObject 사용
         addSceneObject(newObject, rootEntity: rootEntity)
         SoundFX.shared.play(.assetOnVolume)
+        return newObject
     }
     
     // MARK: - Add Sound Object
 
-    func addSoundObject(from asset: Asset, rootEntity: Entity? = nil) {
+    func addSoundObject(from asset: Asset, rootEntity: Entity? = nil) throws -> SceneObject {
+        guard asset.type == .sound else {
+            throw NSError(domain: "Scene", code: 1)
+        }
+        
         // Volume 모드와 Immersive 모드에 따라 다른 초기 위치 설정
         let position: SIMD3<Float>
         if appStateManager.appState.isVolumeOpen {
@@ -55,6 +65,7 @@ extension SceneViewModel {
         // SceneViewModel+SceneObject의 addSceneObject 사용
         addSceneObject(soundObj, rootEntity: rootEntity)
         SoundFX.shared.play(.assetOnVolume)
+        return soundObj
     }
     
     // MARK: - 복제

--- a/Resource/en.lproj/Localizable.strings
+++ b/Resource/en.lproj/Localizable.strings
@@ -59,3 +59,33 @@
 
 // MARK: - Delete Confirmation
 "delete.confirmation" = "Do you want to delete %@?";
+
+// MARK: - Toast
+"toast.addToLibrary.title"    = "에셋 추가 완료";
+"toast.addToLibrary.subtitle" = "에셋이 라이브러리에 저장되었습니다.";
+
+"toast.addToLibraryFail.title"    = "에셋 추가 실패";
+"toast.addToLibraryFail.subtitle" = "라이브러리 저장에 실패했습니다.";
+
+"toast.loadingError.title"    = "불러오기 오류";
+"toast.loadingError.subtitle" = "에셋을 불러오는데 실패했습니다.";
+
+"toast.loadingImageEdit.title" = "이미지 편집 준비 중";
+"toast.loadingAssets.title"    = "에셋 불러오는 중";
+
+"toast.addToVolume.title" = "공간에 추가되었습니다.";
+
+// MARK: - Toast
+"toast.addToLibrary.title" = "Asset Added";
+"toast.addToLibrary.subtitle" = "The asset has been saved to the library.";
+
+"toast.addToLibraryFail.title" = "Failed to Add Asset";
+"toast.addToLibraryFail.subtitle" = "Couldn't save to the library. Please try again.";
+
+"toast.loadingError.title" = "Loading Error";
+"toast.loadingError.subtitle" = "Failed to load the asset.";
+
+"toast.loadingImageEdit.title" = "Preparing Image Edit";
+"toast.loadingAssets.title" = "Loading Assets";
+
+"toast.addToVolume.title" = "Added to the space.";

--- a/Resource/ko.lproj/Localizable.strings
+++ b/Resource/ko.lproj/Localizable.strings
@@ -59,3 +59,18 @@
 
 // MARK: - Delete Confirmation
 "delete.confirmation" = "%@을(를) \n 삭제하시겠습니까?";
+
+// MARK: - Toast
+"toast.addToLibrary.title"    = "에셋 추가 완료";
+"toast.addToLibrary.subtitle" = "에셋이 라이브러리에 저장되었습니다.";
+
+"toast.addToLibraryFail.title"    = "에셋 추가 실패";
+"toast.addToLibraryFail.subtitle" = "라이브러리 저장에 실패했습니다.";
+
+"toast.loadingError.title"    = "불러오기 오류";
+"toast.loadingError.subtitle" = "에셋을 불러오는데 실패했습니다.";
+
+"toast.loadingImageEdit.title" = "이미지 편집 준비 중";
+"toast.loadingAssets.title"    = "에셋 불러오는 중";
+
+"toast.addToVolume.title" = "공간에 추가되었습니다.";


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->

- [x] 오브젝트 추가시 토스트 추가 -> 토스트 언어 로컬라이징 완료

- [x] 사운드 볼륨바 크기 조절 & 커스텀CircleButton 크기 수정
- [x] 사운드 엔티티 볼륨 조절 드래그시 바로바로 되게 수정
         → onVolumeChanging과 onVolumeChange를 분리해서 사운드 변경은 onVolumeChanging때 바로바로 되게, 드래그 끝났을때만 onVolumeChange호출해서 저장로직 수행되게 수정.  
```Swift
    private let onVolumeChanging: ((Double) -> Void)?
    private let onVolumeChange: ((Double) -> Void)?
```
- [x] 뮤트한 상태로 이멀시브 전환하면 뮤트 풀리는 문제해결
         → 전역 뮤트 상태를 스냅샷 기반으로 보존/복원하도록 수정
- [x] 전체 mute 일때 사운드 엔티티 추가시 스냅샷에 추가안되는 문제 해결
         → 뮤트 중 등록(register) 시에도 현재 글로벌 뮤트 스냅샷에 포함되도록 처리

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->



**<1. SceneAudioCoordinator.register 변경>**

```Swift
    /// 새로운 SoundEntity를 등록하여 컨트롤러를 추적
    /// - Parameters:
    ///   - entityId: 엔티티의 고유 식별자(UUID)
    ///   - controller: 등록할 `AudioPlaybackController`
    ///   - shouldStartPlaying: 기본 재생 의도 (초기 볼륨 > 0 등)
    func register(entityId: UUID, controller: AudioPlaybackController, shouldStartPlaying: Bool) {
        controllers[entityId] = WeakController(controller: controller)
        
        if isGlobalMute {
            controller.pause()
            if shouldStartPlaying { appendToGlobalMuteSnapshot(entityId) }
        } else {
            if shouldStartPlaying {
                controller.play()
                playing.insert(entityId)
            }
        }
    }
```
isGlobalMute == true 인 경우:
- 실제 재생은 pause()로 유지
- shouldStartPlaying == true면 현재 글로벌 뮤트 스냅샷에 ID를 추가하여, 뮤트 해제(pop) 시 자동 재생되게 함.

isGlobalMute == false 인 경우:
- shouldStartPlaying == true면 즉시 play() + playing에 반영

**<2. 글로벌 뮤트 스냅샷 조작 헬퍼 추가>**
```Swift
    /// 현재 글로벌 뮤트 스냅샷에 id를 추가 (뮤트 해제 시 자동 재생되도록)
    /// - Parameter id: 추가할 사운드 오브젝트의 id
    private func appendToGlobalMuteSnapshot(_ id: UUID) {
        guard var top = pauseStack.last, top.scope == .globalMute else { return }
        top.snapshot.insert(id)
        pauseStack[pauseStack.count - 1] = top
    }
```
pauseStack top이 .globalMute인 경우에만 안전하게 스냅샷에 삽입

**<3. 뮤트 중 사용자 조작 반영>**
```Swift
    /// 특정 엔티티 일시정지
    /// - Parameter id: 엔티티 UUID
    func pause(_ id: UUID) {
        guard let c = controller(for: id) else { return }
        c.pause()
        playing.remove(id)
        
        if isGlobalMute, var top = pauseStack.last, top.scope == .globalMute {
            top.snapshot.remove(id)
            pauseStack[pauseStack.count - 1] = top
        }
    }
    
    /// 특정 엔티티 정지(재생 위치 초기화 포함)
    /// - Parameter id: 엔티티 UUID
    func stop(_ id: UUID) {
        guard let c = controller(for: id) else { return }
        c.stop()
        playing.remove(id)
        
        if isGlobalMute, var top = pauseStack.last, top.scope == .globalMute {
            top.snapshot.remove(id)
            pauseStack[pauseStack.count - 1] = top
        }
    }
```
전역 뮤트 상태에서 사용자가 특정 사운드를 일시정지/정지로 바꾸면, 글로벌 뮤트 해제 시 자동 재생 대상에서 제외되도록 스냅샷에서도 제거

**<4. popPause(.globalMute)는 기존 스냅샷 복원 로직 유지>**
- 뮤트 진입 전 재생 중이던 항목 + 뮤트 중 등록되어 스냅샷에 추가된 항목이 모두 play()로 복원
