### PR TITLE
Feat - 잠금 기능 추가

### DIFF
--- a/Glayer/Sources/Common/Enum/CircleFillButtonEnum.swift
+++ b/Glayer/Sources/Common/Enum/CircleFillButtonEnum.swift
@@ -62,7 +62,7 @@ enum CircleFillButtonEnum {
     
     var font: Font {
         switch self {
-        case .lock, .crop, .duplicate, .delete, .sound:
+        case .crop, .duplicate, .delete, .sound:
             return .system(size: 17, weight: .medium)
         default:
             return .system(size: 19, weight: .medium)

--- a/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
+++ b/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
@@ -22,7 +22,7 @@ enum AttachmentPositioner {
     ///   - parent: Attachment가 첨부될 부모 Entity
     static func positionAtMiddle(_ attachment: Entity, relativeTo parent: Entity) {
         // 중앙 위치는 parent의 중심점
-        attachment.position = SIMD3<Float>(0, 0, 0.1)
+        attachment.position = SIMD3<Float>(0, 0, 0.01)
     }
     
     /// 하단 위치로 Attachment 설정

--- a/Glayer/Sources/Models/Scene/SceneObjectModels/ImageAttributes.swift
+++ b/Glayer/Sources/Models/Scene/SceneObjectModels/ImageAttributes.swift
@@ -5,17 +5,17 @@ struct ImageAttributes: Codable, Hashable {
     var scale: Float
     var rotation: SIMD3<Float>
     var crop: SIMD4<Float>
-    var billboardable: Bool
+    var lock: Bool
     
     init(
         scale: Float = 1.0,
         rotation: SIMD3<Float> = [0, 0, 0],
         crop: SIMD4<Float> = [0, 0, 1, 1],
-        billboardable: Bool = true
+        lock: Bool = false
     ) {
         self.scale = scale
         self.rotation = rotation
         self.crop = crop
-        self.billboardable = billboardable
+        self.lock = lock
     }
 }

--- a/Glayer/Sources/Models/Scene/SceneObjectModels/SceneObject.swift
+++ b/Glayer/Sources/Models/Scene/SceneObjectModels/SceneObject.swift
@@ -61,10 +61,10 @@ extension SceneObject {
         self.attributes = .image(attrs)
     }
     
-    /// 이미지 billboardable 변경
-    mutating func setBillboardable(_ billboardable: Bool) {
+    /// 이미지 lock 변경
+    mutating func setLock(_ lock: Bool) {
         guard case .image(var attrs) = attributes else { return }
-        attrs.billboardable = billboardable
+        attrs.lock = lock
         self.attributes = .image(attrs)
     }
     

--- a/Glayer/Sources/Models/Scene/SceneObjectModels/SceneObjectCreateExtension.swift
+++ b/Glayer/Sources/Models/Scene/SceneObjectModels/SceneObjectCreateExtension.swift
@@ -11,13 +11,13 @@ extension SceneObject {
         scale: Float = 1.0,
         rotation: SIMD3<Float> = [0, 0, 0],
         crop: SIMD4<Float> = [0, 0, 1, 1],
-        billboardable: Bool = true
+        lock: Bool = false
     ) -> SceneObject {
         let imageAttrs = ImageAttributes(
             scale: scale,
             rotation: rotation,
             crop: crop,
-            billboardable: billboardable
+            lock: lock
         )
         
         return SceneObject(

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/EditBar/EditBarAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/EditBar/EditBarAttachment.swift
@@ -7,6 +7,7 @@ struct EditBarAttachment: View {
     private let objectId: UUID
     private let objectType: AssetType
     
+    private let onLock: (() -> Void)?
     private let onDuplicate: (() -> Void)?
     private let onCrop: (() -> Void)?
     private let onVolumeChanging: ((Double) -> Void)?
@@ -25,6 +26,7 @@ struct EditBarAttachment: View {
     ///   - objectType: 객체의 유형(예: 이미지 또는 사운드)
     ///   - initialVolume: 사운드 객체일 경우 초기 볼륨 값(0~1)
     ///   - onVolumeChange: 볼륨이 변경될 때 호출되는 콜백(사운드 전용)
+    ///   - onLock: 객체 잠금 버튼 탭 시 호출되는 콜백
     ///   - onDuplicate: 객체 복제 버튼 탭 시 호출되는 콜백
     ///   - onCrop: 이미지 크롭 버튼 탭 시 호출되는 콜백
     ///   - onDelete: 객체 삭제 버튼 탭 시 호출되는 콜백
@@ -34,6 +36,7 @@ struct EditBarAttachment: View {
         initialVolume: Double = 1.0,
         onVolumeChanging: ((Double) -> Void)? = nil,
         onVolumeChange: ((Double) -> Void)? = nil,
+        onLock: (() -> Void)? = nil,
         onDuplicate: (() -> Void)? = nil,
         onCrop: (() -> Void)? = nil,
         onDelete: @escaping () -> Void
@@ -43,6 +46,7 @@ struct EditBarAttachment: View {
         self._volume = State(initialValue: min(max(initialVolume, 0.0), 1.0))
         self.onVolumeChanging = onVolumeChanging
         self.onVolumeChange = onVolumeChange
+        self.onLock = onLock
         self.onDuplicate = onDuplicate
         self.onCrop = onCrop
         self.onDelete = onDelete
@@ -56,16 +60,21 @@ struct EditBarAttachment: View {
         HStack(alignment: .center, spacing: 12) {
             switch objectType {
             case .image:
+                // 잠금 버튼
+                CircleFillButton(type: .lock) {
+                    onLock?()
+                }
+                .accessibilityLabel("Lock")
                 // 크롭 버튼
                 //                if let onCrop {
                 //                    CircleFillButton(type: .crop, action: onCrop)
                 //                        .accessibilityLabel("Crop")
                 //                }
                 // 복사 버튼
-                if let onDuplicate {
-                    CircleFillButton(type: .duplicate, action: onDuplicate)
-                        .accessibilityLabel("Duplicate")
+                CircleFillButton(type: .duplicate) {
+                    onDuplicate?()
                 }
+                .accessibilityLabel("Duplicate")
                 
             case .sound:
                 CircleFillButton(
@@ -134,6 +143,7 @@ struct EditBarAttachment: View {
     EditBarAttachment(
         objectId: UUID(),
         objectType: .image,
+        onLock: { print("잠금") },
         onDuplicate: { print("복사") },
         onCrop: { print("크롭") },
         onDelete: { print("삭제") }

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
@@ -9,7 +9,7 @@ struct LockIconAttachment: View {
     @State private var startDate: Date?
     @State private var progress: CGFloat = 0 // 마지막 고정된 값(표시 제어용)
 
-    private let holdDuration: Double = 2
+    private let holdDuration: Double = 1
 
     var body: some View {
         Image(systemName: "lock")

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
@@ -5,6 +5,12 @@ struct LockIconAttachment: View {
     let fontSize = 32.0
     let frameSize = 64.0
 
+    @State private var isPressing = false
+    @State private var startDate: Date?
+    @State private var progress: CGFloat = 0 // 마지막 고정된 값(표시 제어용)
+
+    private let holdDuration: Double = 2
+
     var body: some View {
         Image(systemName: "lock")
             .font(.system(size: fontSize, weight: .medium))
@@ -12,12 +18,54 @@ struct LockIconAttachment: View {
             .background(.ultraThinMaterial, in: Circle())
             .contentShape(Circle())
             .hoverEffect()
-            .gesture(
-                LongPressGesture(minimumDuration: 2)
-                    .onEnded { _ in
-                        onUnlock()
+            .overlay(
+                TimelineView(.animation) { _ in
+                    let currentProgress: CGFloat = {
+                        if let s = startDate, isPressing {
+                            return min(CGFloat(Date().timeIntervalSince(s) / holdDuration), 1)
+                        } else {
+                            return progress
+                        }
+                    }()
+
+                    ZStack {
+                        Circle()
+                            .stroke(.white.opacity(0.25), lineWidth: 4)
+
+                        Circle()
+                            .trim(from: 0, to: currentProgress)
+                            .stroke(
+                                .white,
+                                style: StrokeStyle(lineWidth: 4, lineCap: .round)
+                            )
+                            .rotationEffect(.degrees(-90))
                     }
+                    .padding(6)
+                    .opacity((isPressing || currentProgress > 0) ? 1 : 0)
+                }
             )
+            .onLongPressGesture(minimumDuration: holdDuration, maximumDistance: 20,
+                                pressing: { pressing in
+                if pressing {
+                    isPressing = true
+                    startDate = Date()
+                } else {
+                    // 롱프레스 실패(시간 미만) 시 즉시 리셋
+                    if let s = startDate, Date().timeIntervalSince(s) < holdDuration {
+                        progress = 0
+                    } else {
+                        progress = 1
+                    }
+                    isPressing = false
+                    startDate = nil
+                }
+            }, perform: {
+                onUnlock()
+                // 성공 후 다음 사용을 위해 리셋
+                progress = 0
+                isPressing = false
+                startDate = nil
+            })
     }
 }
 

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct LockIconAttachment: View {
+    let onUnlock: () -> Void
+
+    var body: some View {
+        Image(systemName: "lock")
+            .font(.system(size: 20, weight: .medium))
+            .frame(width: 36, height: 36)
+            .background(.ultraThinMaterial, in: Circle())
+            .contentShape(Circle())
+            .hoverEffect()
+            .gesture(
+                LongPressGesture(minimumDuration: 2)
+                    .onEnded { _ in
+                        onUnlock()
+                    }
+            )
+    }
+}
+
+#Preview {
+    LockIconAttachment(onUnlock: { print("Unlock") })
+}

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
@@ -2,11 +2,13 @@ import SwiftUI
 
 struct LockIconAttachment: View {
     let onUnlock: () -> Void
+    let fontSize = 32.0
+    let frameSize = 64.0
 
     var body: some View {
         Image(systemName: "lock")
-            .font(.system(size: 20, weight: .medium))
-            .frame(width: 36, height: 36)
+            .font(.system(size: fontSize, weight: .medium))
+            .frame(width: frameSize, height: frameSize)
             .background(.ultraThinMaterial, in: Circle())
             .contentShape(Circle())
             .hoverEffect()

--- a/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
@@ -138,6 +138,19 @@ struct SceneRealityView: View {
             sceneObjects: sceneObjects,
             rootEntity: rootEntity
         )
+
+        // 잠금 상태 적용: lock == true 이고 아직 lock 아이콘이 없으면 lockObject 호출
+        for obj in sceneObjects {
+            if case .image(let img) = obj.attributes, img.lock {
+                if let entity = viewModel.getEntity(for: obj.id) {
+                    let hasLockIcon = entity.children.contains { $0.name == "lockIconAttachment" }
+                    if !hasLockIcon {
+                        viewModel.lockObject(id: obj.id)
+                    }
+                }
+            }
+        }
+        
         updateFloorMaterial(content: content, rootEntity: rootEntity)
     }
     

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
@@ -83,6 +83,16 @@ extension SceneViewModel {
             )
             nameAttachment.scale = finalScale
         }
+        
+        // lockIconAttachment 스케일 업데이트
+        if let lockAttachment = entity.children.first(where: { $0.name == "lockIconAttachment" }) {
+            let finalScale = EntityAttachmentSizeDeterminator.calculateFinalScale(
+                headPosition: headPosition,
+                entity: entity,
+                isVolumeMode: isVolumeMode
+            )
+            lockAttachment.scale = finalScale
+        }
     }
     
     // MARK: - Timer Control (Public)
@@ -105,7 +115,6 @@ extension SceneViewModel {
             removeAttachment(from: entity)
         }
     }
-
     /// 특정 Entity의 attachment만 제거
     func removeAttachment(from entity: ModelEntity) {
         // boundBox 제거
@@ -116,9 +125,9 @@ extension SceneViewModel {
             .filter { $0.name == "objectAttachment" }
             .forEach { $0.removeFromParent() }
 
-        // soundNameAttachment 제거 추가
+        // soundNameAttachment 제거
         entity.children
             .filter { $0.name == "soundNameAttachment" }
             .forEach { $0.removeFromParent() }
-        }
+    }
 }

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
@@ -51,6 +51,10 @@ extension SceneViewModel {
             headPosition: headPosition,
             objectId: objectId,
             objectType: objectType,
+            onLock: { [weak self] in
+                guard let self = self else { return }
+                self.lockObject(id: objectId)
+            },
             onDuplicate: { [weak self] in
                 guard let self = self, let rootEntity = self.rootEntity else { return }
                 _ = self.duplicateObject(rootEntity: rootEntity)
@@ -110,6 +114,7 @@ extension SceneViewModel {
         initialVolume: Double? = nil,
         onVolumeChanging: ((Double) -> Void)? = nil,
         onVolumeChange: ((Double) -> Void)? = nil,
+        onLock: (() -> Void)? = nil,
         onDuplicate: (() -> Void)? = nil,
         onCrop: (() -> Void)? = nil,
         onDelete: @escaping () -> Void
@@ -125,6 +130,7 @@ extension SceneViewModel {
                 initialVolume: initialVolume ?? 1.0,
                 onVolumeChanging: onVolumeChanging,
                 onVolumeChange: onVolumeChange,
+                onLock: onLock,
                 onDuplicate: onDuplicate,
                 onCrop: onCrop,
                 onDelete: onDelete
@@ -187,7 +193,48 @@ extension SceneViewModel {
         entity.addChild(nameAttachment)
         AttachmentPositioner.positionAtBottom(nameAttachment, relativeTo: entity)
     }
-    
+
+    /// Lock 아이콘 Attachment 추가
+    func addLockIconAttachment(to entity: ModelEntity) {
+        
+        guard let objectId = UUID(uuidString: entity.name) else { return }
+        
+        let lockAttachment = Entity()
+        lockAttachment.name = "lockIconAttachment"
+        
+        // ViewAttachmentComponent 생성
+        let attachment = ViewAttachmentComponent(
+            rootView: LockIconAttachment(
+                onUnlock: { [weak self] in
+                    guard let self = self else { return }
+                    self.unlockObject(id: objectId)
+                }
+            )
+        )
+        lockAttachment.components.set(attachment)
+        
+        // attachment 스케일 보정
+        let headPosition = userSpatialState.userPosition
+        let finalScale = EntityAttachmentSizeDeterminator.calculateFinalScale(
+            headPosition: headPosition,
+            entity: entity,
+            isVolumeMode: appStateManager.appState.isVolumeOpen
+        )
+        
+        lockAttachment.scale = finalScale
+        entity.addChild(lockAttachment)
+        
+        // Attachment 위치 설정 (중앙)
+        AttachmentPositioner.positionAtMiddle(lockAttachment, relativeTo: entity)
+    }
+
+    /// Lock 아이콘 Attachment 제거
+    func removeLockIconAttachment(from entity: ModelEntity) {
+        entity.children
+            .filter { $0.name == "lockIconAttachment" }
+            .forEach { $0.removeFromParent() }
+    }
+        
     
     // MARK: - dB ↔︎ Linear 변환
     

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImmersiveFeatures.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImmersiveFeatures.swift
@@ -31,7 +31,7 @@ extension SceneViewModel {
             scale: 0.3,
             rotation: SIMD3<Float>(0, 0, 0),
             crop: SIMD4<Float>(0, 0, 1, 1),
-            billboardable: true
+            lock: false
         )
 
         // SceneViewModel+SceneObject의 addSceneObject 사용
@@ -67,6 +67,36 @@ extension SceneViewModel {
         SoundFX.shared.play(.assetOnVolume)
         return soundObj
     }
+
+    func lockObject(id: UUID) {
+        updateSceneObject(with: id) { obj in
+            obj.setLock(true)
+        }
+        
+        // Entity 찾기 및 InputTargetComponent 제거
+        guard let entity = getEntity(for: id) else { return }
+        entity.components.remove(InputTargetComponent.self)
+        
+        // lock 아이콘 attachment 추가
+        addLockIconAttachment(to: entity)
+
+        selectedEntity = nil
+    }
+
+    func unlockObject(id: UUID) {
+        updateSceneObject(with: id) { obj in
+            obj.setLock(false)
+        }
+        
+        // Entity 찾기 및 InputTargetComponent 복원
+        guard let entity = getEntity(for: id) else { return }
+        entity.components.set(InputTargetComponent())
+        
+        // lock 아이콘 attachment 제거
+        removeLockIconAttachment(from: entity)
+
+        selectedEntity = entity
+    }
     
     // MARK: - 복제
     
@@ -86,7 +116,7 @@ extension SceneViewModel {
             scale: imageAttrs.scale,
             rotation: imageAttrs.rotation,
             crop: imageAttrs.crop,
-            billboardable: imageAttrs.billboardable
+            lock: imageAttrs.lock
         )
         
         // SceneViewModel+SceneObject의 addSceneObject 사용


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
기존 ImageAttributes 내에 있는 billboardable을 lock으로 교체했습니다.
lock의 핵심 함수는 addLockIconAttachment, removeLockIconAttachment, lockObject, unlockObject 4개이며, updateScene에 화면 전환 및 load 시 lock attachment를 적용시킬수 있는 코드를 추가했습니다.

lockObject에 addLockIconAttachment를 차용하고 있고, unlockObject에서는 removeLockIconAttachment를 차용하고 있습니다.


## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
https://github.com/user-attachments/assets/8c08e63f-d0b0-4fb6-955b-b64f37a9114c


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
특별히 이번 작업은 다른 분들과 겹치는 부분이 없어 별도의 PR Point는 없지만, 디자인에 있어 개인적으로 개선한 부분이 있어 디자이너와 이야기한 이후 merge를 진행하도록 하겠습니다.