### PR TITLE
Fix - viewMode 진행시 lockAttachment 관련 코드 추가

### DIFF
--- a/Glayer/Sources/Data/UseCase/ViewModeUseCase.swift
+++ b/Glayer/Sources/Data/UseCase/ViewModeUseCase.swift
@@ -35,8 +35,13 @@ struct ViewModeUseCase {
             
             switch entityType {
             case .image:
-                // ImageEntity: InputTargetComponent 제거
-                entity.components.remove(InputTargetComponent.self)
+                // lockIconAttachment 숨기기 (있는 경우만)
+                if let lockIcon = entity.children.first(where: { $0.name == "lockIconAttachment" }) {
+                    lockIcon.scale = SIMD3<Float>(0, 0, 0)
+                }else{
+                    // ImageEntity: InputTargetComponent 제거
+                    entity.components.remove(InputTargetComponent.self)
+                }
                 
             case .sound:
                 // SoundEntity: InputTargetComponent 제거 + opacity 0
@@ -62,8 +67,12 @@ struct ViewModeUseCase {
             
             switch entityType {
             case .image:
-                // ImageEntity: InputTargetComponent 복원
-                entity.components.set(InputTargetComponent())
+                if let lockIcon = entity.children.first(where: { $0.name == "lockIconAttachment" }) {
+                    lockIcon.scale = SIMD3<Float>(1, 1, 1)
+                } else {
+                    // ImageEntity: InputTargetComponent 복원
+                    entity.components.set(InputTargetComponent())
+                }
                 
             case .sound:
                 // SoundEntity: InputTargetComponent 복원 + opacity 1


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
아래와 같이 lockIconAttachment 유무에 따라 있다면 해당 entity의 크기를 0으로, 없다면 InputTargetComponent를 사라지게 만들었습니다. 아래코드는 viewModeOn의 경우이며 viewModeOff의 경우는 반대입니다.
```swift
            case .image:
                // lockIconAttachment 숨기기 (있는 경우만)
                if let lockIcon = entity.children.first(where: { $0.name == "lockIconAttachment" }) {
                    lockIcon.scale = SIMD3<Float>(0, 0, 0)
                }else{
                    // ImageEntity: InputTargetComponent 제거
                    entity.components.remove(InputTargetComponent.self)
                }
```


## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
https://github.com/user-attachments/assets/e0f3d028-a744-45e6-a7f6-f3d123f6726a

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
처음 시도를 했던 방식은 scale을 줄이는 것이 아닌 isEnabled를 false와 true로 변경하는 방식이었습니다. 근데 이를 사용할 경우 attachment동작이 막히게 되는 문제가 발생했습니다.(hovering은 잘됨) 혹시 이유를 안다면 공유해주세요!
