### PR TITLE
Fix - editBar, boundaryBox 수정

### DIFF
--- a/Glayer/Sources/Helpers/Entity/Attachment/EntityBoundBoxApplier.swift
+++ b/Glayer/Sources/Helpers/Entity/Attachment/EntityBoundBoxApplier.swift
@@ -2,15 +2,14 @@ import RealityKit
 import UIKit
 
 enum EntityBoundBoxApplier {
-    static func addBoundAuto(to entity: ModelEntity, width: Float, height: Float) {
+    static func addBoundAuto(to entity: ModelEntity) {
         switch EntityClassifier.classify(entity) {
         case .sound:
-            let diameter = max(width, height)
-            addCircleBound(to: entity, diameter: diameter)
+            addCircleBound(to: entity, diameter: 0.15)
         case .image:
-            addRectBound(to: entity, width: width, height: height)
+            addRectBound(to: entity)
         case .floor:
-            addRectBound(to: entity, width: width, height: height, isFloor: true)
+            addRectBound(to: entity, isFloor: true)
         default:
             return
         }
@@ -18,7 +17,12 @@ enum EntityBoundBoxApplier {
     
     // MARK: - Internal: Rectangle (이미지)
     
-    private static func addRectBound(to entity: ModelEntity, width: Float, height: Float, isFloor: Bool = false) {
+    private static func addRectBound(to entity: ModelEntity, isFloor: Bool = false) {
+        let originalBounds = entity.visualBounds(relativeTo: entity)
+        let width = originalBounds.extents.x
+        let height = originalBounds.extents.y
+        let rotation = quaternionToEuler(entity.orientation)
+
         let offset: Float = isFloor ? 0.1 : 0.08
         let expandedW = width  + offset * 2.5 * 0.3
         let expandedH = height + offset * 2.5 * 0.3
@@ -44,14 +48,19 @@ enum EntityBoundBoxApplier {
         let bound = ModelEntity(mesh: plane, materials: [mat])
         bound.name = "boundBox"
         
-        let vb = entity.visualBounds(relativeTo: entity)
         if isFloor {
             bound.position = SIMD3(0, 0.0001, 0)
             let rotationAngle: Float = -.pi / 2.0
             let rotationAxis = SIMD3<Float>(x: 1.0, y: 0.0, z: 0.0)
             bound.orientation = simd_quatf(angle: rotationAngle, axis: rotationAxis)
         } else {
-            bound.position = vb.center + SIMD3(0, 0, -0.001)
+            bound.orientation = simd_quatf(
+                angle: rotation.x, axis: [1, 0, 0]
+            ) * simd_quatf(
+                angle: rotation.y, axis: [0, 1, 0]
+            ) * simd_quatf(
+                angle: rotation.z, axis: [0, 0, 1]
+            )
         }
         
         entity.addChild(bound)
@@ -92,7 +101,7 @@ enum EntityBoundBoxApplier {
     
     // MARK: - Textures
     
-    private static func makeGlowRectTexture(size: CGSize, cornerRadius: CGFloat, color: UIColor = .white, isFloor: Bool) -> TextureResource? {
+    private static func makeGlowRectTexture(size: CGSize, cornerRadius: CGFloat, color: UIColor = .white, isFloor: Bool, rotation: SIMD3<Float>? = nil) -> TextureResource? {
         let stroke: CGFloat = 1.5
         let glow: CGFloat = 40
         let inset = glow + stroke / 1.5

--- a/Glayer/Sources/Helpers/Entity/Attachment/EntityBoundBoxApplier.swift
+++ b/Glayer/Sources/Helpers/Entity/Attachment/EntityBoundBoxApplier.swift
@@ -18,10 +18,19 @@ enum EntityBoundBoxApplier {
     // MARK: - Internal: Rectangle (이미지)
     
     private static func addRectBound(to entity: ModelEntity, isFloor: Bool = false) {
-        let originalBounds = entity.visualBounds(relativeTo: entity)
-        let width = originalBounds.extents.x
-        let height = originalBounds.extents.y
-        let rotation = quaternionToEuler(entity.orientation)
+        let width: Float
+        let height: Float
+
+        if isFloor {
+            let floorSize: Float = 1
+            width = floorSize
+            height = floorSize
+        } else {
+            let planeEntity = entity.findEntity(named: "imagePlane") as? ModelEntity
+            let planeBounds = planeEntity?.visualBounds(relativeTo: planeEntity)
+            width = planeBounds?.extents.x ?? 0.0
+            height = planeBounds?.extents.y ?? 0.0
+        }
 
         let offset: Float = isFloor ? 0.1 : 0.08
         let expandedW = width  + offset * 2.5 * 0.3
@@ -53,14 +62,6 @@ enum EntityBoundBoxApplier {
             let rotationAngle: Float = -.pi / 2.0
             let rotationAxis = SIMD3<Float>(x: 1.0, y: 0.0, z: 0.0)
             bound.orientation = simd_quatf(angle: rotationAngle, axis: rotationAxis)
-        } else {
-            bound.orientation = simd_quatf(
-                angle: rotation.x, axis: [1, 0, 0]
-            ) * simd_quatf(
-                angle: rotation.y, axis: [0, 1, 0]
-            ) * simd_quatf(
-                angle: rotation.z, axis: [0, 0, 1]
-            )
         }
         
         entity.addChild(bound)

--- a/Glayer/Sources/Helpers/Entity/Environment/FloorEntity.swift
+++ b/Glayer/Sources/Helpers/Entity/Environment/FloorEntity.swift
@@ -108,9 +108,7 @@ class FloorEntity {
     
     static func applyOutline(floor: ModelEntity) {
         EntityBoundBoxApplier.addBoundAuto(
-            to: floor,
-            width: Self.defaultFloorSize.x,
-            height: Self.defaultFloorSize.y
+            to: floor
         )
     }
 }

--- a/Glayer/Sources/Helpers/Entity/Image/ImageEntity.swift
+++ b/Glayer/Sources/Helpers/Entity/Image/ImageEntity.swift
@@ -28,9 +28,7 @@ struct ImageEntity {
         Task { @MainActor in
             await Self.createPlane(
                 to: imageEntity,
-                from: sceneObject,
                 with: asset,
-                imageAttrs: imageAttrs,
                 size: size
             )
         }
@@ -41,6 +39,13 @@ struct ImageEntity {
         )
         imageEntity.components.set(InputTargetComponent())
         imageEntity.components.set(HoverEffectComponent())
+        imageEntity.orientation = simd_quatf(
+            angle: imageAttrs.rotation.x, axis: [1, 0, 0]
+        ) * simd_quatf(
+            angle: imageAttrs.rotation.y, axis: [0, 1, 0]
+        ) * simd_quatf(
+            angle: imageAttrs.rotation.z, axis: [0, 0, 1]
+        )
         
         return imageEntity
     }
@@ -112,9 +117,7 @@ struct ImageEntity {
 
     private static func createPlane(
         to imageEntity: ModelEntity,
-        from sceneObject: SceneObject,
         with asset: Asset,
-        imageAttrs: ImageAttributes,
         size: (width: Float, height: Float)
     ) async {
         guard let material = await createMaterial(from: asset.url) else { return }
@@ -125,9 +128,7 @@ struct ImageEntity {
         )
 
         let plane = ModelEntity(mesh: mesh, materials: [material])
-        plane.position = SIMD3<Float>(0, 0, 0)
-
-        applyRotation(to: plane, rotation: imageAttrs.rotation)
+        plane.name = "imagePlane"
 
         imageEntity.addChild(plane)
     }

--- a/Glayer/Sources/Helpers/Entity/Sound/SoundEntity.swift
+++ b/Glayer/Sources/Helpers/Entity/Sound/SoundEntity.swift
@@ -48,7 +48,6 @@ struct SoundEntity {
         
         let p = sceneObject.position
         modelEntity.position = p
-        modelEntity.scale = [0.3, 0.3, 0.3]
         modelEntity.components.set(InputTargetComponent())
         modelEntity.components.set(HoverEffectComponent())
         modelEntity.components.set(BillboardComponent())
@@ -59,6 +58,7 @@ struct SoundEntity {
                                               in: RealityKitContent.realityKitContentBundle)
                 let node = prefab.clone(recursive: true)
                 node.name = "SoundVisual"
+                node.scale = [0.3, 0.3, 0.3]
                 modelEntity.addChild(node)
                 
                 let b = node.visualBounds(relativeTo: node)

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
@@ -138,12 +138,8 @@ extension SceneViewModel {
         )
         objectAttachment.components.set(attachment)
         objectAttachment.components.set(BillboardComponent())
-        
-        // Entity의 크기 계산 (visualBounds 사용)
-        let bounds = entity.visualBounds(relativeTo: entity)
-        let width  = bounds.extents.x
-        let height = bounds.extents.y
-        EntityBoundBoxApplier.addBoundAuto(to: entity, width: width, height: height)
+
+        EntityBoundBoxApplier.addBoundAuto(to: entity)
 
         /// attachment 스케일 보정
         let finalScale = EntityAttachmentSizeDeterminator.calculateFinalScale(


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
- EditBar sound만 다른 이유 => 전체 entity에 scale 0.3배를 하고 있었음. => 3d 오브젝트에만 0.3배 적용
- boundBox 이상 문제 => ImageEntity 내부에 이미지가 있는것이었고 ImageEntity는 그림을 커버할수 있는 육면체임
	=> 각도를 맞추기 위해 추가 코드를 작성할 경우 중복으로 인한 이상 현상 발생 => 중복 발생 야기 코드 제거
	=> 크기 이상 문제 발생 => 크기 역시도 ImageEntity의 bound를 기준으로 생성, 따라서 내부 Image를 찾아 이를 기반해서 width,height 생성

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
to. Jack
EntityBoundBoxApplier.swift 25번째 줄
```
        if isFloor {
            let floorSize: Float = 1			// 이부분 수정해주시면 됩니다!
            width = floorSize
            height = floorSize
        } else {
            let planeEntity = entity.findEntity(named: "imagePlane") as? ModelEntity
            let planeBounds = planeEntity?.visualBounds(relativeTo: planeEntity)
            width = planeBounds?.extents.x ?? 0.0
            height = planeBounds?.extents.y ?? 0.0
        }
```
