### PR TITLE
Fix - soundAttachment 클릭 안되는 문제 수정

### DIFF
--- a/Glayer/Sources/Helpers/Entity/Sound/SoundEntity.swift
+++ b/Glayer/Sources/Helpers/Entity/Sound/SoundEntity.swift
@@ -58,7 +58,6 @@ struct SoundEntity {
                                               in: RealityKitContent.realityKitContentBundle)
                 let node = prefab.clone(recursive: true)
                 node.name = "SoundVisual"
-                node.scale = [0.3, 0.3, 0.3]
                 modelEntity.addChild(node)
                 
                 let b = node.visualBounds(relativeTo: node)

--- a/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/64D75DB5-B4EE-4911-912F-A68B12404448/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
+++ b/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/64D75DB5-B4EE-4911-912F-A68B12404448/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
@@ -1,4 +1,0 @@
-{
-  "materialPreviewObjectType" : 0,
-  "materialPreviewEnvironmentType" : 2
-}

--- a/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/AF09ED6F-1707-48FD-8720-65B998362C09/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
+++ b/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/AF09ED6F-1707-48FD-8720-65B998362C09/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
@@ -1,4 +1,0 @@
-{
-  "materialPreviewObjectType" : 0,
-  "materialPreviewEnvironmentType" : 2
-}

--- a/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/B3721FB7-E7B7-4A0C-A350-D583E63329C1/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
+++ b/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/B3721FB7-E7B7-4A0C-A350-D583E63329C1/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
@@ -1,4 +1,0 @@
-{
-  "materialPreviewObjectType" : 0,
-  "materialPreviewEnvironmentType" : 2
-}

--- a/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/D66134B1-3681-4A8E-AFE5-29F257229F3B/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
+++ b/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/D66134B1-3681-4A8E-AFE5-29F257229F3B/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
@@ -1,4 +1,0 @@
-{
-  "materialPreviewObjectType" : 0,
-  "materialPreviewEnvironmentType" : 2
-}

--- a/Packages/RealityKitContent/Sources/RealityKitContent/RealityKitContent.rkassets/SoundEntity.usda
+++ b/Packages/RealityKitContent/Sources/RealityKitContent/RealityKitContent.rkassets/SoundEntity.usda
@@ -11,7 +11,7 @@
 def Xform "Root"
 {
     quatf xformOp:orient = (1, 0, 0, 0)
-    float3 xformOp:scale = (1, 1, 1)
+    float3 xformOp:scale = (0.3, 0.3, 0.3)
     float3 xformOp:translate = (0, 0, 0)
     uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
 


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
아주 처음에는 soundEntity 자체를 0.3배 했었음. 이러다 보니 attachment 및 boundbox에 문제가 발생.
이때문에 node에 0.3배 곱하는 방식으로 변경. -> attachment 자체가 클릭이 안되는 문제가 발생
따라서 usda 파일내에서 0.3배를 곱하는 방식을 선택

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
