### PR TITLE
Feat - dragGesture을 통해 움직일때 1/3이하로 내려가지 않게 수정

### DIFF
--- a/Glayer/Sources/Common/Gesture/EntityDragGesture.swift
+++ b/Glayer/Sources/Common/Gesture/EntityDragGesture.swift
@@ -31,10 +31,10 @@ struct EntityDragGesture: ViewModifier {
                                 onGestureStart?()
                                 initialPosition = currentEntity.position
                                 
-                                let bounds = getOriginalEntityBounds(modelEntity)
+                                let bounds = getOriginalEntityBounds(modelEntity, relativeTo: currentEntity.parent)
                                 let entityHeight = bounds.extents.y  // 전체 높이
-                                let halfHeight = entityHeight / 2.0  // 높이의 절반
-                                minY = halfHeight  // 중심점이 최소 halfHeight 이상이어야 하단이 y=0에 닿음
+                                let adjustedHeight = entityHeight / 3.0  // 높이의 3분의 1
+                                minY = SceneConstants.floorYOffset + adjustedHeight  // 중심점이 최소 adjustedHeight 이상이어야 하단이 y=0에 닿음
                             }
                         }
                         
@@ -45,7 +45,9 @@ struct EntityDragGesture: ViewModifier {
                         let newPosition = (initialPosition ?? .zero) + movement
                         
                         // 위치를 영역 내로 제한
-                        currentEntity.position = movementBounds.clamp(newPosition)
+                        var clampedPosition = movementBounds.clamp(newPosition)
+                        clampedPosition.y = max(minY, clampedPosition.y)
+                        currentEntity.position = clampedPosition
                     }
                     .onEnded { value in
                         guard let uuid = UUID(uuidString: value.entity.name) else {

--- a/Glayer/Sources/Common/Gesture/GestureHelpers.swift
+++ b/Glayer/Sources/Common/Gesture/GestureHelpers.swift
@@ -9,12 +9,10 @@ import RealityKit
 ///   - entity: 원본 bounds를 계산할 Entity
 /// - Returns: Entity의 원본 bounds
 @MainActor
-func getOriginalEntityBounds(_ entity: ModelEntity) -> BoundingBox {    
-    // boundBox와 objectAttachment 자식들을 일시적으로 제거
+func getOriginalEntityBounds(_ entity: ModelEntity, relativeTo: Entity? = nil) -> BoundingBox {
     let boundBoxes = entity.children.filter { $0.name == "boundBox" }
     let attachments = entity.children.filter { $0.name == "objectAttachment" }
     
-    // 자식들의 원본 위치 저장 (나중에 복원하기 위해)
     var childPositions: [Entity: SIMD3<Float>] = [:]
     (boundBoxes + attachments).forEach { child in
         childPositions[child] = child.position
@@ -23,10 +21,9 @@ func getOriginalEntityBounds(_ entity: ModelEntity) -> BoundingBox {
     boundBoxes.forEach { $0.removeFromParent() }
     attachments.forEach { $0.removeFromParent() }
     
-    // 원본 엔티티의 bounds 계산
-    let bounds = entity.visualBounds(relativeTo: nil)
+    // ✨ relativeTo 파라미터 사용
+    let bounds = entity.visualBounds(relativeTo: relativeTo)
     
-    // boundBox와 attachment를 다시 추가 (원본 위치로)
     boundBoxes.forEach { box in
         entity.addChild(box)
         box.position = childPositions[box] ?? box.position


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
예전에 만들었던 이미지가 땅아래로 내려가지 않게 했던 기능 재 구현(비율 곱 이후 코드 동작에 문제가 생겨 이를 없엤었음)
- 적용 좌표를 parent로 변경하여 이를 해결 후 재 적용.
- 1/2이하로 내려가지 않게 만들었었지만 누끼를 딸때 완벽한 누끼가 아닐 가능성을 염두해두고 1/3으로 변경함

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
