### PR TITLE
fix: 바닥 이미지 설정 관련 4차 QA 수정 

### DIFF
--- a/Glayer/Sources/Common/Enum/FloorImageState.swift
+++ b/Glayer/Sources/Common/Enum/FloorImageState.swift
@@ -1,0 +1,35 @@
+//
+//  FloorImageState.swift
+//  Glayer
+//
+//  Created by jeongminji on 11/21/25.
+//
+
+import Foundation
+
+/// FloorImageState (바닥 이미지 없음, 이 asset이 현재 바닥 이미지, 다른 asset이 바닥 이미지)
+enum FloorImageState {
+    case none
+    case current
+    case other
+    
+    var changeFloorText: String {
+        switch self {
+        case .none:
+            return String(localized: "floor.add")
+        case .current:
+            return String(localized: "floor.remove")
+        case .other:
+            return String(localized: "floor.change")
+        }
+    }
+    
+    var changeFloorSymbol: String {
+        switch self {
+        case .none, .other:
+            return "square.on.square.dashed"
+        case .current:
+            return "square.dashed"
+        }
+    }
+}

--- a/Glayer/Sources/Common/UIComponent/RenamePopover.swift
+++ b/Glayer/Sources/Common/UIComponent/RenamePopover.swift
@@ -18,7 +18,7 @@ struct RenamePopover: View {
     private let onDelete: ((_ id: String) -> Void)?
     private let onDuplicate: ((_ id: String, _ newTitle: String) -> Void)?
     private let onAddToFloor: ((_ id: String) -> Void)?
-    private let isCurrentFloorImage: Bool
+    private var floorState: FloorImageState = .none
     private let onCancel: () -> Void
 
     @FocusState private var isFocused: Bool
@@ -42,7 +42,7 @@ struct RenamePopover: View {
         onDelete: ((_ id: String) -> Void)? = nil,
         onDuplicate: ((_ id: String, _ newTitle: String) -> Void)? = nil,
         onAddToFloor: ((_ id: String) -> Void)? = nil,
-        isCurrentFloorImage: Bool = false,
+        floorState: FloorImageState = .none,
         onCancel: @escaping () -> Void
     ) {
         self.id = id
@@ -51,7 +51,7 @@ struct RenamePopover: View {
         self.onDelete = onDelete
         self.onDuplicate = onDuplicate
         self.onAddToFloor = onAddToFloor
-        self.isCurrentFloorImage = isCurrentFloorImage
+        self.floorState = floorState
         self.onCancel = onCancel
     }
     
@@ -74,11 +74,7 @@ struct RenamePopover: View {
                     onAddToFloor(id)
                     onCancel()
                 } label: {
-                    if isCurrentFloorImage {
-                        rowLabel(String(localized: "floor.remove"), system: "square.dashed")
-                    } else {
-                        rowLabel(String(localized: "floor.add"), system: "square.on.square.dashed")
-                    }
+                    rowLabel(floorState.changeFloorText, system: floorState.changeFloorSymbol)
                 }
                 .buttonStyle(.plain)
             }

--- a/Glayer/Sources/Presentations/Library/LibraryList/View/LibraryImageItemView.swift
+++ b/Glayer/Sources/Presentations/Library/LibraryList/View/LibraryImageItemView.swift
@@ -13,6 +13,12 @@ struct LibraryImageItemView: View {
     
     private let asset: Asset
     private let allowRename: Bool
+    private var floorState: FloorImageState {
+        guard let id = sceneViewModel.spacialEnvironment.floorAssetId else {
+            return .none
+        }
+        return id == asset.id ? .current : .other
+    }
     
     @Environment(LibraryViewModel.self) private var viewModel
     @Environment(SceneViewModel.self) private var sceneViewModel
@@ -100,17 +106,21 @@ struct LibraryImageItemView: View {
             perform: { showRenamePopover = true }
         )
         .popover(isPresented: $showRenamePopover, attachmentAnchor: .point(.bottom), arrowEdge: .top) {
+            let onFloorAction: (String) -> Void = { _ in
+                if sceneViewModel.spacialEnvironment.floorAssetId == asset.id {
+                    sceneViewModel.removeFloorImage()
+                } else {
+                    sceneViewModel.applyFloorImage(from: asset)
+                }
+            }
+
             if !allowRename {
-                RenamePopover(id: asset.id,
-                              title: $draftTitle,
-                              onAddToFloor: { _ in
-                    if sceneViewModel.spacialEnvironment.floorAssetId == asset.id {
-                        sceneViewModel.removeFloorImage()
-                    } else {
-                        sceneViewModel.applyFloorImage(from: asset)
-                    }
-                },
-                              onCancel: { showRenamePopover = false }
+                RenamePopover(
+                    id: asset.id,
+                    title: $draftTitle,
+                    onAddToFloor: onFloorAction,
+                    floorState: floorState,
+                    onCancel: { showRenamePopover = false }
                 )
             } else {
                 RenamePopover(
@@ -120,14 +130,8 @@ struct LibraryImageItemView: View {
                         startInlineRename()
                     },
                     onDelete: { id in viewModel.deleteAsset(id: id) },
-                    onAddToFloor: { _ in
-                        if sceneViewModel.spacialEnvironment.floorAssetId == asset.id {
-                            sceneViewModel.removeFloorImage()
-                        } else {
-                            sceneViewModel.applyFloorImage(from: asset)
-                        }
-                    },
-                    isCurrentFloorImage: sceneViewModel.spacialEnvironment.floorAssetId == asset.id,
+                    onAddToFloor: onFloorAction,
+                    floorState: floorState,
                     onCancel: { showRenamePopover = false }
                 )
             }

--- a/Resource/en.lproj/Localizable.strings
+++ b/Resource/en.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 // MARK: - Floor Image
 "floor.remove" = "Remove Floor Image";
 "floor.add" = "Add Floor Image";
+"floor.change" = "Change Floor Image";
 
 // MARK: - Mode
 "mode.label" = "Mode";

--- a/Resource/ko.lproj/Localizable.strings
+++ b/Resource/ko.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 // MARK: - Floor Image
 "floor.remove" = "바닥 이미지 제거";
 "floor.add" = "바닥 이미지 추가";
+"floor.change" = "바닥 이미지 변경";
 
 // MARK: - Mode
 "mode.label" = "모드";


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
- [x] 기본 이미지의 경우 바닥이미지 선택 후 다시 눌렀을 때 삭제로 바꾸기
-> 현재 기본 이미지의 경우 적용이 안되어있음 (유저 추가 에셋의 경우 적용되어있음)
- [x] 다른 에셋 선택할 때 ‘바닥이미지 변경’으로 바꾸기 (한국어, 영어 둘 다 체크 필요)

바닥을 다루는 상태가 true, false가 아니라 3개의 상태로 바뀌어서 enum을 하나 만들어 줬습니다!
```Swfit
enum FloorImageState {
    case none // 추가된 바닥이 없는 경우
    case current // 추가된 바닥이 나인 경우
    case other // 추가된 바닥이 다른 에셋인 경우
    
    var changeFloorText: String {
        switch self {
        case .none:
            return String(localized: "floor.add")
        case .current:
            return String(localized: "floor.remove")
        case .other:
            return String(localized: "floor.change")
        }
    }
    
    var changeFloorSymbol: String {
        switch self {
        case .none, .other:
            return "square.on.square.dashed"
        case .current:
            return "square.dashed"
        }
    }
}
```

RenamePopover에서 isCurrentFloorImage대신 FloorImageState를 받도록 변경했습니다.
그리고 FloorImageState에 따라 버튼에 대한 텍스트와 심볼이 자동으로 바뀌도록 하였습니다. 
```Swfit
            if let onAddToFloor {
                Button {
                    onAddToFloor(id)
                    onCancel()
                } label: {
                    rowLabel(floorState.changeFloorText, system: floorState.changeFloorSymbol)
                }
                .buttonStyle(.plain)
            }
```

사용하는 곳
```Swfit
.popover(isPresented: $showRenamePopover, attachmentAnchor: .point(.bottom), arrowEdge: .top) {
            let onFloorAction: (String) -> Void = { _ in
                if sceneViewModel.spacialEnvironment.floorAssetId == asset.id {
                    sceneViewModel.removeFloorImage()
                } else {
                    sceneViewModel.applyFloorImage(from: asset)
                }
            }

            if !allowRename {
                RenamePopover(
                    id: asset.id,
                    title: $draftTitle,
                    onAddToFloor: onFloorAction,
                    floorState: floorState,
                    onCancel: { showRenamePopover = false }
                )
            } else {
                RenamePopover(
                    id: asset.id,
                    title: $draftTitle,
                    onRename: {
                        startInlineRename()
                    },
                    onDelete: { id in viewModel.deleteAsset(id: id) },
                    onAddToFloor: onFloorAction,
                    floorState: floorState,
                    onCancel: { showRenamePopover = false }
                )
            }
        }
```


## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

https://github.com/user-attachments/assets/7efa8a0f-eafb-40ed-b532-790af2687025


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
