### PR TITLE
fix: 토스트 중첩시 안사라지는 에러 해결

### DIFF
--- a/Glayer/Sources/Common/Modifier/Toast/ToastPresenter.swift
+++ b/Glayer/Sources/Common/Modifier/Toast/ToastPresenter.swift
@@ -10,6 +10,7 @@ import SwiftUI
 private struct ToastPresenter: ViewModifier {
     @Binding private var isPresented: Bool
     private let message: ToastMessage
+    @State private var dismissTask: Task<Void, Never>?
     
     /// init
     /// - Parameters:
@@ -27,29 +28,22 @@ private struct ToastPresenter: ViewModifier {
             if isPresented {
                 ToastView(
                     message: message,
-                    dismissAction: { withAnimation(.easeInOut) { isPresented = false } }
+                    dismissAction: {
+                        withAnimation(.easeInOut) { isPresented = false }
+                    }
                 )
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment(for: message.position))
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity,
+                    alignment: alignment(for: message.position)
+                )
                 .transition(.opacity)
-                .onAppear {
-                    if let sfx = message.sfx {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                            SoundFX.shared.play(sfx)
-                        }
-                    }
-                    
-                    switch message.dismissMode {
-                    case let .auto(duration):
-                        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
-                            withAnimation(.easeInOut(duration: 0.18)) { isPresented = false }
-                        }
-                    default:
-                        break
-                    }
-                }
             }
         }
         .animation(.easeInOut(duration: 0.18), value: isPresented)
+        .onChange(of: isPresented) { _, newValue in
+            handlePresentedChange(newValue)
+        }
     }
     
     /// ToastPosition에 따라 Alignment를 반환
@@ -60,6 +54,31 @@ private struct ToastPresenter: ViewModifier {
         case .top:    return .top
         case .center: return .center
         case .bottom: return .bottom
+        }
+    }
+    
+    /// 토스트 표시 상태가 변할 때마다 호출되어 자동 해제 타이머와 사운드 재생을 관리
+    /// - Parameter isShown: 토스트가 화면에 표시되었는지 여부 (`true`면 표시됨)
+    private func handlePresentedChange(_ isShown: Bool) {
+        dismissTask?.cancel()
+        
+        guard isShown else {
+            return
+        }
+        
+        if let sfx = message.sfx {
+            SoundFX.shared.play(sfx)
+        }
+        
+        guard case let .auto(duration) = message.dismissMode else {
+            return
+        }
+        
+        dismissTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(duration))
+            withAnimation(.easeInOut(duration: 0.18)) {
+                isPresented = false
+            }
         }
     }
 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
- [x]  토스트 중첩시 안사라지는 에러 해결

<기존 코드>
지금 ToastPresenter는 onAppear 안에서 DispatchQueue.main.asyncAfter를 사용
```Swift
.onAppear {
    if let sfx = message.sfx {
        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
            SoundFX.shared.play(sfx)
        }
    }
    
    switch message.dismissMode {
    case let .auto(duration):
        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
            withAnimation(.easeInOut(duration: 0.18)) { isPresented = false }
        }
    default:
        break
    }
}
```
문제정:
같은 isPresented에 대해 여러 번 auto-dismiss 타이머가 생길 수 있고
그 중 일부는 이미 내려가야 할 타이밍에 다시 올라와 있더라도 isPresented = false를 때리거나,
반대로, 사용자가 isPresented를 다시 true로 만들어도 새 타이머가 안 잡히는 경우가 생김
(이미 화면에 떠 있어서 onAppear가 다시 안 불리는 경우 등)

<새로 고친 코드>
**토스트 1개 = 타이머 1개를 강제**
isPresented가 true가 될 때마다 기존 타이머(Task)를 취소하고 새 타이머 하나만 만들도록 수정

```Swift
    /// 토스트 표시 상태가 변할 때마다 호출되어 자동 해제 타이머와 사운드 재생을 관리
    /// - Parameter isShown: 토스트가 화면에 표시되었는지 여부 (`true`면 표시됨)
    private func handlePresentedChange(_ isShown: Bool) {
        dismissTask?.cancel()
        
        guard isShown else {
            return
        }
        
        if let sfx = message.sfx {
            SoundFX.shared.play(sfx)
        }
        
        guard case let .auto(duration) = message.dismissMode else {
            return
        }
        
        dismissTask = Task { @MainActor in
            try? await Task.sleep(for: .seconds(duration))
            withAnimation(.easeInOut(duration: 0.18)) {
                isPresented = false
            }
        }
    }
```
ToastPresenter 안에 dismiss용 Task 하나를 들고 있게함

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

https://github.com/user-attachments/assets/88da8d50-e418-454b-9bf4-629b683ce050


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
