### PR TITLE
Fix - attachment 위치 highfi에 맞게 수정

### DIFF
--- a/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
+++ b/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
@@ -8,20 +8,26 @@ enum AttachmentPositioner {
     /// - Parameters:
     ///   - attachment: 위치를 설정할 Attachment Entity
     ///   - parent: Attachment가 첨부될 부모 Entity
-    static func positionAtTop(_ attachment: Entity, relativeTo parent: Entity) {
+    static func positionAtTop(_ attachment: Entity, relativeTo parent: Entity, isVolumeMode: Bool) {
         let objectBounds = parent.visualBounds(relativeTo: parent)
         let attachmentBounds = attachment.visualBounds(relativeTo: nil)
-        let parentScale = parent.scale(relativeTo: nil)
+
+        let parentScale: SIMD3<Float>
+
+        if isVolumeMode {
+            parentScale = parent.scale(relativeTo: parent)
+        } else {
+            parentScale = parent.scale(relativeTo: nil)
+        }
 
         let baseLine: Float
         let margin: Float
 
         if let imagePlane = parent.findEntity(named: "imagePlane") {
             let planeBounds = imagePlane.visualBounds(relativeTo: parent)
-            let planeMargin = min(planeBounds.extents.x, planeBounds.extents.y) // 높이
-            margin = planeMargin * 1/4
+            let planeMargin = min(planeBounds.extents.x, planeBounds.extents.y)
+            margin = planeMargin * 1/8
             baseLine = planeBounds.max.y
-            print("planeMargin: \(planeMargin)")
         } else {
             baseLine = objectBounds.max.y
             margin = min(objectBounds.extents.x, objectBounds.extents.y) * 1/4
@@ -29,7 +35,7 @@ enum AttachmentPositioner {
 
         let attachmentHalfHeight = (attachmentBounds.extents.y / 2) / parentScale.y
         
-        let yOffset: Float = baseLine + margin + attachmentHalfHeight //objectBounds.max.y + margin + attachmentMargin
+        let yOffset: Float = baseLine + margin// + attachmentHalfHeight //objectBounds.max.y + margin + attachmentMargin
         attachment.position = SIMD3<Float>(0, yOffset, 0.01)
     }
     

--- a/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
+++ b/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
@@ -11,14 +11,7 @@ enum AttachmentPositioner {
     static func positionAtTop(_ attachment: Entity, relativeTo parent: Entity, isVolumeMode: Bool) {
         let objectBounds = parent.visualBounds(relativeTo: parent)
         let attachmentBounds = attachment.visualBounds(relativeTo: nil)
-
-        let parentScale: SIMD3<Float>
-
-        if isVolumeMode {
-            parentScale = parent.scale(relativeTo: parent)
-        } else {
-            parentScale = parent.scale(relativeTo: nil)
-        }
+        let parentScale: SIMD3<Float> = parent.scale(relativeTo: nil)
 
         let baseLine: Float
         let margin: Float
@@ -26,16 +19,25 @@ enum AttachmentPositioner {
         if let imagePlane = parent.findEntity(named: "imagePlane") {
             let planeBounds = imagePlane.visualBounds(relativeTo: parent)
             let planeMargin = min(planeBounds.extents.x, planeBounds.extents.y)
-            margin = planeMargin * 1/8
+            
+            let width = planeBounds.extents.x
+            let height = planeBounds.extents.y
+            let glowCorrection = EntityBoundBoxApplier.calculateGlowCorrection(width: width, height: height)
+            
             baseLine = planeBounds.max.y
+            margin = planeMargin/4 - glowCorrection.height/2
         } else {
+            let width = objectBounds.extents.x
+            let height = objectBounds.extents.y
+            let glowCorrection = EntityBoundBoxApplier.calculateGlowCorrection(width: width, height: height)
+            
             baseLine = objectBounds.max.y
-            margin = min(objectBounds.extents.x, objectBounds.extents.y) * 1/4
+            margin = min(objectBounds.extents.x, objectBounds.extents.y)/4 - glowCorrection.height/2
         }
 
         let attachmentHalfHeight = (attachmentBounds.extents.y / 2) / parentScale.y
         
-        let yOffset: Float = baseLine + margin// + attachmentHalfHeight //objectBounds.max.y + margin + attachmentMargin
+        let yOffset: Float = baseLine + attachmentHalfHeight + margin // 이미지 최상단 + 어태치 먼트 바닥 + 마진(사진 마진/4 - 라인값/2)
         attachment.position = SIMD3<Float>(0, yOffset, 0.01)
     }
     

--- a/Glayer/Sources/Helpers/Entity/Attachment/EntityBoundBoxApplier.swift
+++ b/Glayer/Sources/Helpers/Entity/Attachment/EntityBoundBoxApplier.swift
@@ -175,7 +175,7 @@ enum EntityBoundBoxApplier {
     }
 
     /// Glow 효과로 인해 줄어드는 크기를 보정하기 위한 값 계산
-    private static func calculateGlowCorrection(width: Float, height: Float) -> (width: Float, height: Float) {
+    static func calculateGlowCorrection(width: Float, height: Float) -> (width: Float, height: Float) {
         let texW: CGFloat = 1024
         let texH: CGFloat = max(768, texW * CGFloat(height / max(width, 0.001)))
         let inset: CGFloat = 41  // makeGlowRectTexture의 inset 값 (glow + stroke/1.5)

--- a/Glayer/Sources/Helpers/Entity/Image/ImageEntity.swift
+++ b/Glayer/Sources/Helpers/Entity/Image/ImageEntity.swift
@@ -22,9 +22,9 @@ struct ImageEntity {
         let imageEntity = ModelEntity()
         imageEntity.name = sceneObject.id.uuidString
         imageEntity.position = sceneObject.position
-        imageEntity.scale = SIMD3<Float>(repeating: 1.0) // 명시적으로 1.0 설정 (크기는 mesh에 반영)
+        imageEntity.scale = SIMD3<Float>(repeating: imageAttrs.scale)
 
-        let size = calculateSize(from: asset, imageAttrs: imageAttrs)
+        let size = calculateSize(from: asset)
 
         Task { @MainActor in
             await Self.createPlane(
@@ -54,10 +54,8 @@ struct ImageEntity {
     // MARK: - Helper Methods
     
     /// 크기 계산
-    private static func calculateSize(from asset: Asset, imageAttrs: ImageAttributes) -> (width: Float, height: Float) {
-        let baseSize: Float = 0.5
-        let baseWidth = baseSize * imageAttrs.scale
-        
+    private static func calculateSize(from asset: Asset) -> (width: Float, height: Float) {
+        let baseWidth: Float = 0.5
         let imageWidth = Float(asset.image?.width ?? 1)
         let imageHeight = Float(asset.image?.height ?? 1)
         let aspectRatio = imageWidth > 0 ? (imageHeight / imageWidth) : 1.0

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
@@ -72,6 +72,7 @@ extension SceneViewModel {
                 isVolumeMode: isVolumeMode
             )
             objectAttachment.scale = finalScale
+            AttachmentPositioner.positionAtTop(objectAttachment, relativeTo: entity, isVolumeMode: isVolumeMode)
         }
         
         // soundNameAttachment 스케일 업데이트

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
@@ -152,7 +152,7 @@ extension SceneViewModel {
         entity.addChild(objectAttachment)
 
         // Attachment 위치 설정 (상단)
-        AttachmentPositioner.positionAtTop(objectAttachment, relativeTo: entity)
+        AttachmentPositioner.positionAtTop(objectAttachment, relativeTo: entity, isVolumeMode: appStateManager.appState.isVolumeOpen)
     }
     
     private func addSoundNameAttachment(to entity: ModelEntity, headPosition: SIMD3<Float>, sceneObject: SceneObject) {


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
editbar attachment 위치 설정
- 이미지의 최상단을 baseLine으로
- margin을 planeMargin의 1/4 - glowLine의 1/2 
- attachmentHalfHeight를 계산해서 이를 더해서 위치를 설정


추가적으로 Entity에 scale값이 1이고 plane을 생성할대 scale을 적용했었음.
이를 Entity에 적용되게 변경

