### PR TITLE
Fix - 화면 전환시 viewMode에 따른 lock버튼 여부 및 앞뒤로 Lock 생기게 수정

### DIFF
--- a/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
@@ -144,12 +144,14 @@ struct SceneRealityView: View {
         )
 
         // 잠금 상태 적용: lock == true 이고 아직 lock 아이콘이 없으면 lockObject 호출
-        for obj in sceneObjects {
-            if case .image(let img) = obj.attributes, img.lock {
-                if let entity = viewModel.getEntity(for: obj.id) {
-                    let hasLockIcon = entity.children.contains { $0.name == "lockIconAttachment" }
-                    if !hasLockIcon {
-                        viewModel.lockObject(id: obj.id)
+        if !viewModel.userSpatialState.viewMode {
+            for obj in sceneObjects {
+                if case .image(let img) = obj.attributes, img.lock {
+                    if let entity = viewModel.getEntity(for: obj.id) {
+                        let hasLockIcon = entity.children.contains { $0.name == "lockIconAttachment" }
+                        if !hasLockIcon {
+                            viewModel.lockObject(id: obj.id)
+                        }
                     }
                 }
             }

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
@@ -190,15 +190,10 @@ extension SceneViewModel {
         AttachmentPositioner.positionAtBottom(nameAttachment, relativeTo: entity)
     }
 
-    /// Lock 아이콘 Attachment 추가
-    func addLockIconAttachment(to entity: ModelEntity) {
+    /// Lock Icon Entity 생성 헬퍼 함수
+    private func createLockIconEntity(objectId: UUID, zPosition: Float) -> Entity {
+        let lockIcon = Entity()
         
-        guard let objectId = UUID(uuidString: entity.name) else { return }
-        
-        let lockAttachment = Entity()
-        lockAttachment.name = "lockIconAttachment"
-        
-        // ViewAttachmentComponent 생성
         let attachment = ViewAttachmentComponent(
             rootView: LockIconAttachment(
                 onUnlock: { [weak self] in
@@ -207,9 +202,26 @@ extension SceneViewModel {
                 }
             )
         )
-        lockAttachment.components.set(attachment)
         
-        // attachment 스케일 보정
+        lockIcon.components.set(attachment)
+        lockIcon.position = SIMD3<Float>(0, 0, zPosition)
+        
+        return lockIcon
+    }
+
+    /// Lock 아이콘 Attachment 추가 (앞면과 뒷면 모두)
+    func addLockIconAttachment(to entity: ModelEntity) {
+        guard let objectId = UUID(uuidString: entity.name) else { return }
+        
+        // 부모 Entity (기존 이름 유지)
+        let lockAttachment = Entity()
+        lockAttachment.name = "lockIconAttachment"
+        
+        // 앞면과 뒷면 Lock Icon 생성 및 추가
+        lockAttachment.addChild(createLockIconEntity(objectId: objectId, zPosition: 0.01))
+        lockAttachment.addChild(createLockIconEntity(objectId: objectId, zPosition: -0.01))
+        
+        // 스케일 보정
         let headPosition = userSpatialState.sceneHeadAnchor.position
         let finalScale = EntityAttachmentSizeDeterminator.calculateFinalScale(
             headPosition: headPosition,
@@ -220,7 +232,7 @@ extension SceneViewModel {
         lockAttachment.scale = finalScale
         entity.addChild(lockAttachment)
         
-        // Attachment 위치 설정 (중앙)
+        // 위치 설정
         AttachmentPositioner.positionAtMiddle(lockAttachment, relativeTo: entity)
     }
 


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
1. viewMode 여부에 따라 lock 아이콘을 생성시킬지 말지를 updateScene에서 결정
2. SceneVM+EditBarAttachment.swift에서 아이콘을 생성 시키는 부분을 함수화, 앞 뒤로 두개를 생성 시킴

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
lock 아이콘을 생성시키는 함수를 추가하고 이를 통해 앞뒤로 아이콘을 생성시킵니다.