### PR TITLE
Fix - 오브젝트 맨 앞으로 끌어오는 경우 클릭 안되는 버그 수정

### DIFF
--- a/Glayer/Sources/Models/Scene/SceneConstants.swift
+++ b/Glayer/Sources/Models/Scene/SceneConstants.swift
@@ -30,12 +30,14 @@ struct SceneConstants {
 
     /// 오브젝트 이동 범위의 기본값
     /// 바닥 크기를 기준으로 자동 계산
+    /// Volume 경계를 벗어나지 않도록 X, Z축에 여유 공간 추가
     static var defaultMovementBounds: MovementBounds {
         let half = floorHalfSize
+        let margin: Float = 0.01  // Volume 경계 여유 공간
         return MovementBounds(
-            minX: -half, maxX: half,
+            minX: -half + margin, maxX: half - margin,
             minY: -half, maxY: half,
-            minZ: -half, maxZ: half
+            minZ: -half + margin, maxZ: half - margin
         )
     }
     


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
오브젝트 이동범위 마진 추가해서 클릭 안되는 이슈 해결

**원인**
이미지를 최대 앞으로 끌어오게 되면 제스처 가능 영역과 겹치게 되는데, 이미지의 미세한 두꼐로 인해 제스처 가능 범위를 벗어나서 클릭이 안됨.
약간의 마진을(0.01) 추가해서 이미지 두께로 인해 제스처 가능 범위를 벗어나지 않도록 제어.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
