### PR TITLE
feat: 크롭 전체 영역 이동 드래그 추가

### DIFF
--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/Crop/CropOverlay.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/Crop/CropOverlay.swift
@@ -25,6 +25,12 @@ struct CropOverlay: View {
     
     @State private var dragStartRect: CGRect = .zero
     @State private var activeCorner: Corner?
+    @State private var dragMode: DragMode?
+    
+    enum DragMode {
+        case corner(Corner)
+        case move
+    }
     
     // MARK: - Body
     
@@ -35,9 +41,20 @@ struct CropOverlay: View {
                 
                 ForEach(Corner.allCases, id: \.self) { corner in
                     let center = cornerCenter(corner, L: L, W: actualLineWidth)
-                    
+
+                    let isGlowing: Bool = {
+                        switch dragMode {
+                        case .move:
+                            return true
+                        case .corner(let active):
+                            return active == corner
+                        default:
+                            return false
+                        }
+                    }()
+
                     ZStack {
-                        if activeCorner == corner {
+                        if isGlowing {
                             CornerBracket(length: L, lineWidth: actualLineWidth, cornerRadius: 30)
                                 .foregroundStyle(.white)
                                 .blur(radius: 8)
@@ -48,7 +65,7 @@ struct CropOverlay: View {
                                     y: 0
                                 )
                         }
-                        
+
                         CornerBracket(length: L, lineWidth: actualLineWidth, cornerRadius: 30)
                             .foregroundStyle(.white)
                     }
@@ -56,6 +73,7 @@ struct CropOverlay: View {
                     .position(center)
                     .allowsHitTesting(false)
                 }
+
             }
             .contentShape(Rectangle())
             .gesture(resizeGesture(in: geo.size))
@@ -148,85 +166,126 @@ extension CropOverlay {
     }
 }
 
-// MARK: - 드래그 제스처 (한 번만 붙이고, 안에서 코너 분기)
+// MARK: - 드래그 제스처 (코너 리사이즈 + 전체 이동)
 
 extension CropOverlay {
     private func resizeGesture(in frameSize: CGSize) -> some Gesture {
         DragGesture()
             .onChanged { gesture in
                 let L = cornerLength(for: cropRect.size)
+                
                 if dragStartRect == .zero {
                     dragStartRect = cropRect
-                    activeCorner = closestCorner(
+                    
+                    if let corner = closestCorner(
                         point: gesture.startLocation,
                         L: L,
                         hitPadding: 0
-                    )
+                    ) {
+                        activeCorner = corner
+                        dragMode = .corner(corner)
+                    } else if cropRect.contains(gesture.startLocation) {
+                        activeCorner = nil
+                        dragMode = .move
+                    } else {
+                        dragMode = nil
+                        return
+                    }
                 }
                 
-                guard let corner = activeCorner else { return }
+                guard let dragMode else { return }
                 
-                let start = dragStartRect
                 let dx = gesture.translation.width
                 let dy = gesture.translation.height
                 
-                var newMinX = start.minX
-                var newMaxX = start.maxX
-                var newMinY = start.minY
-                var newMaxY = start.maxY
-                
-                switch corner {
-                case .topLeft:
-                    newMinX = start.minX + dx
-                    newMinY = start.minY + dy
+                switch dragMode {
+                case .corner(let corner):
+                    resizeFromCorner(corner: corner, dx: dx, dy: dy)
                     
-                case .topRight:
-                    newMaxX = start.maxX + dx
-                    newMinY = start.minY + dy
-                    
-                case .bottomLeft:
-                    newMinX = start.minX + dx
-                    newMaxY = start.maxY + dy
-                    
-                case .bottomRight:
-                    newMaxX = start.maxX + dx
-                    newMaxY = start.maxY + dy
+                case .move:
+                    moveWholeRect(dx: dx, dy: dy)
                 }
-                
-                let minSize: CGFloat = 10
-                
-                newMinX = max(imageFrame.minX, min(newMinX, imageFrame.maxX - minSize))
-                newMaxX = min(imageFrame.maxX, max(newMaxX, imageFrame.minX + minSize))
-                
-                if newMaxX - newMinX < minSize {
-                    if corner == .topLeft || corner == .bottomLeft {
-                        newMinX = newMaxX - minSize
-                    } else {
-                        newMaxX = newMinX + minSize
-                    }
-                }
-                
-                newMinY = max(imageFrame.minY, min(newMinY, imageFrame.maxY - minSize))
-                newMaxY = min(imageFrame.maxY, max(newMaxY, imageFrame.minY + minSize))
-                
-                if newMaxY - newMinY < minSize {
-                    if corner == .topLeft || corner == .topRight {
-                        newMinY = newMaxY - minSize
-                    } else {
-                        newMaxY = newMinY + minSize
-                    }
-                }
-                
-                cropRect = CGRect(
-                    x: newMinX,
-                    y: newMinY,
-                    width: newMaxX - newMinX,
-                    height: newMaxY - newMinY
-                )
             }
             .onEnded { _ in
                 dragStartRect = .zero
+                dragMode = nil
                 activeCorner = nil
             }
+    }
+    
+    // MARK: - 코너 리사이즈
+
+    private func resizeFromCorner(corner: Corner, dx: CGFloat, dy: CGFloat) {
+        let start = dragStartRect
+        
+        var newMinX = start.minX
+        var newMaxX = start.maxX
+        var newMinY = start.minY
+        var newMaxY = start.maxY
+        
+        switch corner {
+        case .topLeft:
+            newMinX = start.minX + dx
+            newMinY = start.minY + dy
+            
+        case .topRight:
+            newMaxX = start.maxX + dx
+            newMinY = start.minY + dy
+            
+        case .bottomLeft:
+            newMinX = start.minX + dx
+            newMaxY = start.maxY + dy
+            
+        case .bottomRight:
+            newMaxX = start.maxX + dx
+            newMaxY = start.maxY + dy
+        }
+        
+        let minSize: CGFloat = 10
+        
+        newMinX = max(imageFrame.minX, min(newMinX, imageFrame.maxX - minSize))
+        newMaxX = min(imageFrame.maxX, max(newMaxX, imageFrame.minX + minSize))
+        
+        if newMaxX - newMinX < minSize {
+            if corner == .topLeft || corner == .bottomLeft {
+                newMinX = newMaxX - minSize
+            } else {
+                newMaxX = newMinX + minSize
+            }
+        }
+        
+        newMinY = max(imageFrame.minY, min(newMinY, imageFrame.maxY - minSize))
+        newMaxY = min(imageFrame.maxY, max(newMaxY, imageFrame.minY + minSize))
+        
+        if newMaxY - newMinY < minSize {
+            if corner == .topLeft || corner == .topRight {
+                newMinY = newMaxY - minSize
+            } else {
+                newMaxY = newMinY + minSize
+            }
+        }
+        
+        cropRect = CGRect(
+            x: newMinX,
+            y: newMinY,
+            width: newMaxX - newMinX,
+            height: newMaxY - newMinY
+        )
+    }
+    
+    // MARK: - 전체 이동
+
+    private func moveWholeRect(dx: CGFloat, dy: CGFloat) {
+        var newRect = dragStartRect.offsetBy(dx: dx, dy: dy)
+        
+        let minX = imageFrame.minX
+        let maxX = imageFrame.maxX - newRect.width
+        let minY = imageFrame.minY
+        let maxY = imageFrame.maxY - newRect.height
+        
+        newRect.origin.x = min(max(newRect.origin.x, minX), maxX)
+        newRect.origin.y = min(max(newRect.origin.y, minY), maxY)
+        
+        cropRect = newRect
     }
 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
- [x] 크롭 전체 영역 이동 드래그  추가


- `CropOverlay`에서 드래그 모드를 구분
```Swift
    enum DragMode {
        case corner(Corner)
        case move
    }
```

- `CropOverlay`에서 드래그 모드를 구분하는 `dragMode` 기반으로 하이라이트 로직 수정
  - 이동 모드(`.move`)일 때 네 개 코너 브래킷이 모두 glow 되도록 변경
  - 코너 리사이즈 모드(`.corner`)일 때는 해당 코너만 glow 유지
```Swift
ForEach(Corner.allCases, id: \.self) { corner in
                    let center = cornerCenter(corner, L: L, W: actualLineWidth)

                    let isGlowing: Bool = {
                        switch dragMode {
                        case .move:
                            return true
                        case .corner(let active):
                            return active == corner
                        default:
                            return false
                        }
                    }()

                    ZStack {
                        if isGlowing {
                            CornerBracket(length: L, lineWidth: actualLineWidth, cornerRadius: 30)
                                .foregroundStyle(.white)
                                .blur(radius: 8)
                                .shadow(
                                    color: .white.opacity(0.5),
                                    radius: 30,
                                    x: 0,
                                    y: 0
                                )
                        }

                        CornerBracket(length: L, lineWidth: actualLineWidth, cornerRadius: 30)
                            .foregroundStyle(.white)
                    }
```
- 드래그 모드에 따라 rect 크롭 값 수정하는 resizeFromCorner, moveWholeRect 함수 분리해서 호출
```Swift
private func resizeGesture(in frameSize: CGSize) -> some Gesture {
        DragGesture()
            .onChanged { gesture in
                let L = cornerLength(for: cropRect.size)
                
                if dragStartRect == .zero {
                    dragStartRect = cropRect
                    
                    if let corner = closestCorner(
                        point: gesture.startLocation,
                        L: L,
                        hitPadding: 0
                    ) {
                        activeCorner = corner
                        dragMode = .corner(corner)
                    } else if cropRect.contains(gesture.startLocation) {
                        activeCorner = nil
                        dragMode = .move
                    } else {
                        dragMode = nil
                        return
                    }
                }
                
                guard let dragMode else { return }
                
                let dx = gesture.translation.width
                let dy = gesture.translation.height
                
                switch dragMode {
                case .corner(let corner):
                    resizeFromCorner(corner: corner, dx: dx, dy: dy)
                    
                case .move:
                    moveWholeRect(dx: dx, dy: dy)
                }
            }
            .onEnded { _ in
                dragStartRect = .zero
                dragMode = nil
                activeCorner = nil
            }
    }
```

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

https://github.com/user-attachments/assets/dff9c150-8a9d-4c15-b615-0fb74b79ec78


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
