### PR TITLE
Fix - project_json 파일 변경

### DIFF
--- a/Glayer/Sources/Helpers/FileManager/Core/FilePathProvider.swift
+++ b/Glayer/Sources/Helpers/FileManager/Core/FilePathProvider.swift
@@ -26,7 +26,7 @@ struct FilePathProvider {
     // SceneModel 저장용 - Project 객체는 인메모리 DB에 저장
     static func projectMetadataFile(projectName: String) -> URL {
         projectDirectory(projectName: projectName)
-            .appendingPathComponent("\(projectName)_project.json")
+            .appendingPathComponent("project.json")
     }
     
     // MARK: - 프로젝트의 이미지

--- a/Glayer/Sources/Helpers/FileManager/Storages/ProjectFileStorage.swift
+++ b/Glayer/Sources/Helpers/FileManager/Storages/ProjectFileStorage.swift
@@ -27,7 +27,6 @@ struct ProjectFileStorage: FileStorageProtocol {
         let oldProjectDir = FilePathProvider.projectDirectory(projectName: oldProjectName)
         let newProjectDir = FilePathProvider.projectDirectory(projectName: newProjectName)
 
-        // 기존 프로젝트 디렉토리가 존재, 새 프로젝트 디렉토리 존재 확인
         guard fileManager.fileExists(atPath: oldProjectDir.path) else {
             throw FileStorageError.fileNotFound
         }
@@ -37,14 +36,6 @@ struct ProjectFileStorage: FileStorageProtocol {
 
         // 프로젝트 디렉토리 이름 변경
         try fileManager.moveItem(at: oldProjectDir, to: newProjectDir)
-
-        // 메타데이터 파일 이름 변경
-        let oldMetadataFile = oldProjectDir.appendingPathComponent("\(oldProjectName)_project.json")
-        let newMetadataFile = newProjectDir.appendingPathComponent("\(newProjectName)_project.json")
-
-        if fileManager.fileExists(atPath: oldMetadataFile.path) {
-            try fileManager.moveItem(at: oldMetadataFile, to: newMetadataFile)
-        }
     }
     
     func delete(projectName: String) throws {


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
프로젝트 json 파일 이름 변경했습니다.
기존 \(procjectName)_project.json 으로 저장되었지만 project.json으로 변경했습니다.
기존 ProjectFileStorage에 rename을 사용하여 project name 변경시 함께 변경되게 하는 방식이 맞을 수 있지만 스페이스바 라던지 파일이름에 함께 존재하면 안되는 기호들이 함께 있을때 예외처리를 현재 작업 할 수 없어 project.json으로 통일했습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
