### PR TITLE
Fix - volume상태 viewMode 활성화 시 Library 최소화 구현

### DIFF
--- a/Glayer/App/MainWindowContentView.swift
+++ b/Glayer/App/MainWindowContentView.swift
@@ -23,7 +23,6 @@ struct MainWindowContent: View {
         Group {
             if appStateManager.appState.selectedProject != nil {
                 VStack {
-                    if appStateManager.isLibraryOpen {
                         LibraryView(
                             viewModel: LibraryViewModel(
                                 appStateManager: appStateManager,
@@ -42,7 +41,6 @@ struct MainWindowContent: View {
                             }
 
                         }
-                    }
                 }
                 .environment(appStateManager)
                 .task {

--- a/Glayer/Sources/Data/Repositories/EntityRepository.swift
+++ b/Glayer/Sources/Data/Repositories/EntityRepository.swift
@@ -143,6 +143,11 @@ final class EntityRepository: EntityRepositoryInterface {
             if let existingEntity = entityMap[sceneObject.id] {
                 // 기존 엔티티의 위치 업데이트
                 existingEntity.position = sceneObject.position
+
+                if existingEntity.parent !== rootEntity {
+                    existingEntity.removeFromParent()
+                    rootEntity.addChild(existingEntity)
+                }
             } else {
                 // 새로운 엔티티 생성
                 _ = createEntity(from: sceneObject, asset: asset, rootEntity: rootEntity, viewMode: viewMode)

--- a/Glayer/Sources/Presentations/Coordinator/AppStateManager.swift
+++ b/Glayer/Sources/Presentations/Coordinator/AppStateManager.swift
@@ -131,7 +131,7 @@ class AppStateManager {
         }
         selectedScene = nil
         appState = .projectList
-        // 보기모드 활성화 되어있는 경우
+        // 보기모드 활성화 되어있는 경우 보기모드 값 초기화
         if !showLibrary {
             toggleLibraryVisibility()
         }
@@ -155,7 +155,7 @@ class AppStateManager {
     }
 
     /// LibraryView의 표시/숨김 상태 토글
-    /// Immersive 모드에서 뷰 모드 활성화 시 사용
+    /// Immersive 및 volume 모드에서 뷰 모드 활성화 시 사용
     func toggleLibraryVisibility() {
         withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
             showLibrary.toggle()

--- a/Glayer/Sources/Presentations/Coordinator/AppStateManager.swift
+++ b/Glayer/Sources/Presentations/Coordinator/AppStateManager.swift
@@ -157,7 +157,9 @@ class AppStateManager {
     /// LibraryView의 표시/숨김 상태 토글
     /// Immersive 모드에서 뷰 모드 활성화 시 사용
     func toggleLibraryVisibility() {
-        showLibrary.toggle()
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
+            showLibrary.toggle()
+        }
     }
     
     /// LibraryView의 최소화 상태 토글

--- a/Glayer/Sources/Presentations/Coordinator/AppStateManager.swift
+++ b/Glayer/Sources/Presentations/Coordinator/AppStateManager.swift
@@ -57,7 +57,7 @@ class AppStateManager {
     private(set) var selectedScene: SceneModel?
     
     /// LibraryView 표시 여부
-    /// Immersive에서 viewMode 상태일 때 false로 설정되어 LibraryView만 숨김
+    /// Immersive와 volume모두 viewMode 상태일 때 false로 설정되어 LibraryView만 숨김
     private(set) var showLibrary: Bool = true
 
     /// LibraryView 최소화 상태
@@ -122,6 +122,20 @@ class AppStateManager {
         }
         appState = .libraryWithImmersive(project)
     }
+    
+    /// volume모드에서 X버튼을 클릭하여 volume을 직접 닫는 경우 프로젝트 목록으로 전환
+    /// 보기모드 활성화시 보기모드 값 초기화
+    func closeVolume() {
+        guard appState.isVolumeOpen else {
+            return
+        }
+        selectedScene = nil
+        appState = .projectList
+        // 보기모드 활성화 되어있는 경우
+        if !showLibrary {
+            toggleLibraryVisibility()
+        }
+    }
 
     /// Immersive 모드를 닫고 Volume 모드로 돌아가는 상태로 전환
     /// libraryWithImmersive 상태에서만 호출 가능
@@ -137,10 +151,6 @@ class AppStateManager {
     /// LibraryView가 현재 열려있는지 확인
     /// - Returns: showLibrary가 true이고 libraryMinimized가 false일 때 true 반환
     var isLibraryOpen: Bool {
-        guard case .libraryWithImmersive = appState else {
-            return true
-        }
-        
         return showLibrary && !libraryMinimized
     }
 

--- a/Glayer/Sources/Presentations/Library/LibraryList/View/LibraryView.swift
+++ b/Glayer/Sources/Presentations/Library/LibraryList/View/LibraryView.swift
@@ -39,30 +39,32 @@ struct LibraryView: View {
         ZStack {
             VStack(spacing: 8) {
                 headerView
-                
-                TabView(selection: $viewModel.assetType) {
-                    LibraryImageTabGridView(
-                        assets: viewModel.filteredAndSorted(type: .image, key: viewModel.searchText),
-                        onAdded: { showAddedToast = true }
-                    )
-                    .tabItem { Label(String(localized: "library.image"), systemImage: "photo.fill") }
-                    .tag(AssetType.image)
-                    
-                    LibrarySoundTabListView(
-                        assets: viewModel.filteredAndSorted(type: .sound, key: viewModel.searchText),
-                        onAdded: { showAddedToast = true }
-                    )
-                    .tabItem {
-                        Label {
-                            Text(String(localized: "library.sound"))
-                        } icon: {
-                            Image(.icBeamNote)
-                                .renderingMode(.template)
+
+                if appStateManager.isLibraryOpen {
+                    TabView(selection: $viewModel.assetType) {
+                        LibraryImageTabGridView(
+                            assets: viewModel.filteredAndSorted(type: .image, key: viewModel.searchText),
+                            onAdded: { showAddedToast = true }
+                        )
+                        .tabItem { Label(String(localized: "library.image"), systemImage: "photo.fill") }
+                        .tag(AssetType.image)
+
+                        LibrarySoundTabListView(
+                            assets: viewModel.filteredAndSorted(type: .sound, key: viewModel.searchText),
+                            onAdded: { showAddedToast = true }
+                        )
+                        .tabItem {
+                            Label {
+                                Text(String(localized: "library.sound"))
+                            } icon: {
+                                Image(.icBeamNote)
+                                    .renderingMode(.template)
+                            }
                         }
+                        .tag(AssetType.sound)
                     }
-                    .tag(AssetType.sound)
+                    .toast(isPresented: $showAddedToast, message: .addToVolume)
                 }
-                .toast(isPresented: $showAddedToast, message: .addToVolume)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding(.bottom, 20)

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Immersive/ImmersiveSceneView.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Immersive/ImmersiveSceneView.swift
@@ -21,7 +21,11 @@ struct ImmersiveSceneView: View {
             appStateManager.openVolume()
         }
         .onDisappear {
-            viewModel.reset()
+            // Volume으로 전환 중이 아닐 때만 reset 호출
+            // Volume이 이미 열려있으면 엔티티를 재사용해야 하므로 reset 건너뜀
+            if !appStateManager.appState.isVolumeOpen {
+                viewModel.reset()
+            }
         }
     }
 }

--- a/Glayer/Sources/Presentations/SceneRealityView/View/VolumeScene/VolumeSceneView.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/VolumeScene/VolumeSceneView.swift
@@ -18,8 +18,12 @@ struct VolumeSceneView: View {
                 config: .volume
             )
             .onDisappear {
-                viewModel.reset()
-                
+                // Immersive로 전환 중이 아닐 때만 reset 호출
+                // Immersive가 이미 열려있으면 엔티티를 재사용해야 하므로 reset 건너뜀
+                if !appStateManager.appState.isImmersiveOpen {
+                    viewModel.reset()
+                }
+
                 // 사용자가 시스템 X 버튼으로 VolumeWindow를 닫은 경우 AppState 동기화
                 appStateManager.closeVolume()
             }

--- a/Glayer/Sources/Presentations/SceneRealityView/View/VolumeScene/VolumeSceneView.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/VolumeScene/VolumeSceneView.swift
@@ -21,9 +21,7 @@ struct VolumeSceneView: View {
                 viewModel.reset()
                 
                 // 사용자가 시스템 X 버튼으로 VolumeWindow를 닫은 경우 AppState 동기화
-                if case .libraryWithVolume = appStateManager.appState {
-                    appStateManager.closeProject()
-                }
+                appStateManager.closeVolume()
             }
             VStack {
                 Spacer()


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
volume상태에서 viewMode활성화한 경우 발생하는 아래 두 가지 문제를 해결하기 위한 기능 구현

1. ImageEntity새로 생성하는 경우 해당 에셋 편집 가능한 현상
2. SoundEntity 생성시 Entity가 나타나지 않아 새로 생성되었는지에 대한 피드백 부족

viewMode활성화된 상태에서 volume닫는 경우 프로젝트 리스트로 돌아가고 다시 MainWindow 나타나도록 구현



### **주요 변경 사항**
#### **Volume 모드에서 Library 최소화 기능 구현**
- `AppStateManager.swift`에서 Library표시 여부를 Immersive와 volume모두 반영하도록 변경.
- `AppStateManager.swift`에 `closeVolume()`함수를 통해 volume을 닫을 때 Library 떠 있는 상태, 최소화된 상태 두 가지 case 커버




#### **Library 최소화 방식 변경**
- 기존: `MainWindowContentView.swift`에서 if문을 통해 라이브러리 표시 여부 판단하여 LibraryView를 렌더링할지 결정
```swift
if appStateManager.isLibraryOpen {
    LibraryView()
}
```
- 변경: `isLibraryOpen`값에 따라서 LibraryView하단 opacity값 0 or 1로 조절. LibraryView내부 TabView는 기존 방식 사용.

기존 방식으로 LibraryView를 아예 렌더링하지 않는 경우 volume이 닫히면 앱이 종료되버려서 opacity로 안보이게 하는 방법 채택.




#### **`AppStateManagement.swift`에서 showLibrary 토글 함수에 애니메이션 추가**
- volume을 닫고 프로젝트 목록으로 돌아가는 상황에서 LibraryView의 TabView가 뒤늦게 사라지는 현상 방지


## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

![Simulator Screen Recording - Apple Vision Pro - 2025-12-30 at 16 27 11](https://github.com/user-attachments/assets/721640f6-5f9b-4fc6-9e4e-ea981f94010f)
volume에서 Library 최소화 (최소화되는 애니메이션 추가)

![toggleLibrary_nonAnimation](https://github.com/user-attachments/assets/829e12af-0fcb-439b-8d24-7780d8fce495)
volume닫는 경우 LibraryView의 TabView 뒤늦게 사라지는 문제

![toggleLibrary_Animation](https://github.com/user-attachments/assets/4b04090f-f8df-4a9c-8241-ea937dee71af)
LibraryToggle함수에 애니메이션 추가해서 해결


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
