### PR TITLE
Fix - 잠금 아이콘 2개 표시되는 문제 수정

### DIFF
--- a/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
+++ b/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
@@ -59,7 +59,7 @@ enum AttachmentPositioner {
     ///   - parent: Attachment가 첨부될 부모 Entity
     static func positionAtMiddle(_ attachment: Entity, relativeTo parent: Entity) {
         // 중앙 위치는 parent의 중심점
-        attachment.position = SIMD3<Float>(0, 0, 0.01)
+        attachment.position = SIMD3<Float>(0, 0, 0)
     }
     
     /// 하단 위치로 Attachment 설정

--- a/Glayer/Sources/Presentations/Library/LibraryList/View/LibraryImageItemView.swift
+++ b/Glayer/Sources/Presentations/Library/LibraryList/View/LibraryImageItemView.swift
@@ -100,10 +100,10 @@ struct LibraryImageItemView: View {
         .onLongPressGesture(
             minimumDuration: 0.35,
             maximumDistance: 22,
-            pressing: { p in
+            perform: { showRenamePopover = true },
+            onPressingChanged: { p in
                 withAnimation(.easeInOut(duration: 0.12)) { isFlashing = p }
-            },
-            perform: { showRenamePopover = true }
+            }
         )
         .popover(isPresented: $showRenamePopover, attachmentAnchor: .point(.bottom), arrowEdge: .top) {
             let onFloorAction: (String) -> Void = { _ in

--- a/Glayer/Sources/Presentations/Library/LibraryList/View/LibrarySoundItemView.swift
+++ b/Glayer/Sources/Presentations/Library/LibraryList/View/LibrarySoundItemView.swift
@@ -126,15 +126,17 @@ struct LibrarySoundItemView: View {
             tapFlash()
             onRowTap?()
         }
-        .onLongPressGesture(minimumDuration: 0.35, maximumDistance: 22,
-                            pressing: { p in
-            guard allowRename else { return }
-            withAnimation(.easeInOut(duration: 0.12)) { isFlashing = p }
-        },
-                            perform: {
-            guard allowRename else { return }
-            showRenamePopover = true
-        }
+        .onLongPressGesture(
+            minimumDuration: 0.35,
+            maximumDistance: 22,
+            perform: {
+                guard allowRename else { return }
+                showRenamePopover = true
+            },
+            onPressingChanged: { p in
+                guard allowRename else { return }
+                withAnimation(.easeInOut(duration: 0.12)) { isFlashing = p }
+            }
         )
         .popover(
             isPresented: Binding(

--- a/Glayer/Sources/Presentations/ProjectList/View/ProjectItemView.swift
+++ b/Glayer/Sources/Presentations/ProjectList/View/ProjectItemView.swift
@@ -82,10 +82,10 @@ struct ProjectItemView: View {
         .onLongPressGesture(
             minimumDuration: 0.35,
             maximumDistance: 22,
-            pressing: { p in
+            perform: { showRenamePopover = true },
+            onPressingChanged: { p in
                 withAnimation(.easeInOut(duration: 0.12)) { isFlashing = p }
-            },
-            perform: { showRenamePopover = true }
+            }
         )
         .popover(
             isPresented: $showRenamePopover,

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
@@ -44,28 +44,32 @@ struct LockIconAttachment: View {
                     .opacity((isPressing || currentProgress > 0) ? 1 : 0)
                 }
             )
-            .onLongPressGesture(minimumDuration: holdDuration, maximumDistance: 20,
-                                pressing: { pressing in
-                if pressing {
-                    isPressing = true
-                    startDate = Date()
-                } else {
-                    // 롱프레스 실패(시간 미만) 시 즉시 리셋
-                    if let s = startDate, Date().timeIntervalSince(s) < holdDuration {
-                        progress = 0
-                    } else {
-                        progress = 1
-                    }
+            .onLongPressGesture(
+                minimumDuration: holdDuration,
+                maximumDistance: 20,
+                perform: {
+                    onUnlock()
+                    // 성공 후 다음 사용을 위해 리셋
+                    progress = 0
                     isPressing = false
                     startDate = nil
+                },
+                onPressingChanged: { pressing in
+                    if pressing {
+                        isPressing = true
+                        startDate = Date()
+                    } else {
+                        // 롱프레스 실패(시간 미만) 시 즉시 리셋
+                        if let s = startDate, Date().timeIntervalSince(s) < holdDuration {
+                            progress = 0
+                        } else {
+                            progress = 1
+                        }
+                        isPressing = false
+                        startDate = nil
+                    }
                 }
-            }, perform: {
-                onUnlock()
-                // 성공 후 다음 사용을 위해 리셋
-                progress = 0
-                isPressing = false
-                startDate = nil
-            })
+            )
     }
 }
 

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
@@ -223,8 +223,8 @@ extension SceneViewModel {
         lockAttachment.name = "lockIconAttachment"
         
         // 앞면과 뒷면 Lock Icon 생성 및 추가
-        lockAttachment.addChild(createLockIconEntity(objectId: objectId, zPosition: 0.01))
-        lockAttachment.addChild(createLockIconEntity(objectId: objectId, zPosition: -0.01))
+        lockAttachment.addChild(createLockIconEntity(objectId: objectId, zPosition: 0.001))
+        lockAttachment.addChild(createLockIconEntity(objectId: objectId, zPosition: -0.001))
         
         // 스케일 보정
         let headPosition = userSpatialState.sceneHeadAnchor.position


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
**문제**
ImageEnttiy 앞,뒷면으로 잠금 아이콘을 배치하다 보니, 간격이 멀어 2개가 겹쳐보이는 문제 발생.

**해결 방법**
ImageEntity와의 z거리 0.01 -> 0.001 로 축소

attachment.position (0, 0, 0.01) -> (0, 0, 0)
- attachment의 z position값이 0.01로 되어있어, entity크기를 키울 수록 LockIcon이 앞으로 이동하는 문제 해결.


**추가 수정 내용**
<img width="1249" height="218" alt="image" src="https://github.com/user-attachments/assets/18ede3e5-c764-437c-b915-a1f0b8dd40c9" />
기존 onLongPressGesture가 deprecated API라서, 새로운 API로 마이그레이션 작업

<img width="1279" height="311" alt="image" src="https://github.com/user-attachments/assets/2b543d47-bc49-4100-b8e0-b48efb23e43e" />
새로운 API는 파라미터 이름과, 순서만 조금 달라서 로직 변경은 X
가독성 측면에서 리뉴얼 된 것으로 보임.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
![longSpacing_LockIcon](https://github.com/user-attachments/assets/51acdbb2-0dbb-4315-b713-686e109d9ec3)
기존 간격

![closeSpacing_LockICon](https://github.com/user-attachments/assets/55b346ed-0bb0-4c91-9134-46075bb715a8)
수정 후 간격

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->

![Simulator Screen Recording - Apple Vision Pro - 2025-12-31 at 12 28 10](https://github.com/user-attachments/assets/135bd7ab-5ff1-4c27-9d3c-6774c322105b)
해당 의자 에셋처럼 이미지 상단 여백이 많은 경우 자물쇠가 이미지 위에 배치되는 현상이 발생합니다.
다만, 이미지 자체의 문제인 것 같아서 추가로 수정할 필요는 없어 보이는데 좋은 의견 있으시면 부탁드립니다 ~!
