### PR TITLE
Fix - 에셋 잠금 해제 중복으로 되는 현상 수정

### DIFF
--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/LockIcon/LockIconAttachment.swift
@@ -8,6 +8,7 @@ struct LockIconAttachment: View {
     @State private var isPressing = false
     @State private var startDate: Date?
     @State private var progress: CGFloat = 0 // 마지막 고정된 값(표시 제어용)
+    @State private var didUnlock = false // 중복 unlock 호출 방지
 
     private let holdDuration: Double = 1
 
@@ -48,6 +49,8 @@ struct LockIconAttachment: View {
                 minimumDuration: holdDuration,
                 maximumDistance: 20,
                 perform: {
+                    guard !didUnlock else { return } // 이미 unlock 되었으면 스킵
+                    didUnlock = true
                     onUnlock()
                     // 성공 후 다음 사용을 위해 리셋
                     progress = 0
@@ -58,12 +61,18 @@ struct LockIconAttachment: View {
                     if pressing {
                         isPressing = true
                         startDate = Date()
+                        didUnlock = false // 새 제스처 시작 시 리셋
                     } else {
                         // 롱프레스 실패(시간 미만) 시 즉시 리셋
                         if let s = startDate, Date().timeIntervalSince(s) < holdDuration {
                             progress = 0
                         } else {
                             progress = 1
+                            // Fallback: perform이 호출되지 않았으면 여기서 unlock
+                            if !didUnlock {
+                                didUnlock = true
+                                onUnlock()
+                            }
                         }
                         isPressing = false
                         startDate = nil

--- a/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
@@ -160,6 +160,13 @@ struct SceneRealityView: View {
         if !viewModel.userSpatialState.viewMode {
             for obj in sceneObjects {
                 if case .image(let img) = obj.attributes, img.lock {
+                    // 현재 lock 상태 재확인 (race condition 방지)
+                    guard let currentObj = viewModel.sceneObjects.first(where: { $0.id == obj.id }),
+                          case .image(let currentImg) = currentObj.attributes,
+                          currentImg.lock else {
+                        continue
+                    }
+
                     if let entity = viewModel.getEntity(for: obj.id) {
                         let hasLockIcon = entity.children.contains { $0.name == "lockIconAttachment" }
                         if !hasLockIcon {

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
@@ -217,7 +217,11 @@ extension SceneViewModel {
     /// Lock 아이콘 Attachment 추가 (앞면과 뒷면 모두)
     func addLockIconAttachment(to entity: ModelEntity) {
         guard let objectId = UUID(uuidString: entity.name) else { return }
-        
+
+        // 중복 생성 방지
+        let hasLockIcon = entity.children.contains { $0.name == "lockIconAttachment" }
+        if hasLockIcon { return }
+
         // 부모 Entity (기존 이름 유지)
         let lockAttachment = Entity()
         lockAttachment.name = "lockIconAttachment"


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
이미지 엔티티 스케일 조정 후 Lock Icon을 두 번 해제해야 잠금이 풀리는 버그를 수정했습니다.

### 문제 발생 시나리오
- 이미지 스케일을 키운 후 잠금 설정 시, 일정 확률로 Lock Icon 한 개를 해제해도 잠금이 풀리지 않음
- Progress 게이지가 100% 차지만 unlock이 실행되지 않는 경우 발생
- 동일한 Lock Icon을 다시 해제하거나 다른 Lock Icon을 해제해야 잠금 해제됨

### 문제 원인
#### **원인 1. onLongPressGesture 타이밍 이슈**
- `perform` 클로저가 호출되지 않아도 `onPressingChanged`에서 `progress = 1`로 설정

#### **원인 2. Race Condition 발생**
- unlock 직후에도 옛날 데이터(`lock = true`)를 보고 재잠금 발생

### 변경 내용

#### **1. onLongPressGesture 타이밍 이슈**
`LockIconAttachment.swift`
- `.onLongPressGesture`의 `perform`이 호출되지 않을 경우, `onPressingChanged`에서 잠금 해제

#### **1. Race Condition 해결**
`SceneRealityView.swift`
- 이전에 snapshot된 `sceneObjects`를 통해 잠금을 비교하지 않고, 현재의 값으로 잠금 상태 재확인

`SceneViewModel.EditBarAttachment.swift`
- Lock Icon 존재하는지 확인하고, 중복 생성 방지

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
