### PR TITLE
feat: 에셋 생성위치 중복 해결

### DIFF
--- a/Glayer/Sources/Data/UseCase/CreateObjectUseCase.swift
+++ b/Glayer/Sources/Data/UseCase/CreateObjectUseCase.swift
@@ -27,7 +27,8 @@ struct CreateObjectUseCase {
     let assetRepository: AssetRepositoryInterface
     let sceneObjectRepository: SceneObjectRepositoryInterface
     let entityRepository: EntityRepositoryInterface
-
+    let placementPolicy: ObjectPlacementPolicy
+    
     /// SceneObject를 씬에 추가하고 대응되는 RealityKit 엔티티를 생성합니다.
     /// - Parameters:
     ///   - object: 추가할 `SceneObject`
@@ -46,15 +47,26 @@ struct CreateObjectUseCase {
     ///   4) SceneObject와 Entity는 동일한 UUID로 연결됨
     @MainActor
     func execute(object: SceneObject, rootEntity: Entity, scene: inout SceneModel, viewMode: Bool) throws -> CreateObjectResult {
-        // 1. Asset 조회
+        var object = object
+        
+        // 1. 기존 오브젝트들의 position을 모아서
+        let existingPositions = scene.sceneObjects.map { $0.position }
+        
+        // 2. 위치 정책 적용 (bounds 안 + 안 겹치게)
+        object.position = placementPolicy.adjustedPosition(
+            base: object.position,
+            existingPositions: existingPositions
+        )
+        
+        // 3. Asset 조회
         guard let asset = assetRepository.asset(withId: object.assetId) else {
             throw CreateObjectError.assetNotFound
         }
-
-        // 2. SceneObject를 씬에 추가
+        
+        // 4. SceneObject를 씬에 추가
         sceneObjectRepository.addObject(object, to: &scene)
-
-        // 3. Entity 생성 (현재 viewMode 상태 전달)
+        
+        // 5. Entity 생성 (현재 viewMode 상태 전달)
         guard let entity = entityRepository.createEntity(
             from: object,
             asset: asset,
@@ -63,7 +75,7 @@ struct CreateObjectUseCase {
         ) else {
             throw CreateObjectError.entityCreationFailed
         }
-
+        
         return CreateObjectResult(
             createdObject: object,
             createdEntity: entity

--- a/Glayer/Sources/Helpers/Entity/Environment/ObjectPlacementPolicy.swift
+++ b/Glayer/Sources/Helpers/Entity/Environment/ObjectPlacementPolicy.swift
@@ -1,0 +1,143 @@
+//
+//  ObjectPlacementPolicy.swift
+//  Glayer
+//
+//  Created by jeongminji on 1/4/26.
+//
+
+import Foundation
+import simd
+
+struct ObjectPlacementPolicy {
+    
+    // MARK: - Properties
+
+    private let movementBounds: MovementBounds
+    private let minDistance: Float
+    
+    // MARK: - Init
+
+    /// Init
+    /// - Parameters:
+    ///   - movementBounds: 배치 가능한 xyz 범위
+    ///   - minDistance: 다른 오브젝트와의 최소 거리
+    init(
+           movementBounds: MovementBounds? = nil,
+           minDistance: Float = 0.03
+    ) {
+        self.movementBounds = movementBounds ?? SceneConstants.defaultMovementBounds
+        self.minDistance = minDistance
+    }
+
+    // MARK: - Public Methods
+
+    /// 새 오브젝트의 최종 배치 위치 계산
+    /// - Parameters:
+    ///   - base: 사용자가 의도한 기본 위치 (예: 원본 오브젝트 근처, 카메라 앞 등)
+    ///   - existingPositions: 현재 씬에 존재하는 모든 SceneObject의 position 배열
+    /// - Returns: MovementBounds 안에 있으며, 기존 오브젝트와 최소 거리를 만족하려고 시도한 최종 위치
+    ///
+    /// 동작 순서:
+    /// 1. base 위치를 bounds 안으로 clamp
+    /// 2. 기존 오브젝트들과 minDistance 이상 떨어져 있다면 그대로 사용
+    /// 3. 겹친다면, base 주변을 원형/나선형으로 돌며 비어 있는 위치를 탐색
+    /// 4. 끝까지 못 찾으면 clamp된 위치를 그대로 반환 (최악의 fallback)
+    func adjustedPosition(
+        base: SIMD3<Float>,
+        existingPositions: [SIMD3<Float>]
+    ) -> SIMD3<Float> {
+        let clamped = clampPosition(base, bounds: movementBounds, margin: minDistance)
+
+        if isFreePosition(clamped,
+                          existingPositions: existingPositions,
+                          minDistance: minDistance) {
+            return clamped
+        }
+
+        let maxRadiusX = max(movementBounds.maxX - clamped.x,
+                             clamped.x - movementBounds.minX)
+        let maxRadiusZ = max(movementBounds.maxZ - clamped.z,
+                             clamped.z - movementBounds.minZ)
+        let maxRadius = min(maxRadiusX, maxRadiusZ)
+        
+        let angleStep: Float = .pi / 12
+        let radiusStep: Float = minDistance * 0.8
+
+        var angle: Float = 0
+        var radius: Float = minDistance
+
+        var steps = 0
+        let maxSteps = 2000
+
+        while radius <= maxRadius && steps < maxSteps {
+            let offset = SIMD3<Float>(
+                x: cos(angle) * radius,
+                y: 0,
+                z: sin(angle) * radius
+            )
+
+            var candidate = clamped + offset
+            candidate = clampPosition(candidate,
+                                      bounds: movementBounds,
+                                      margin: minDistance)
+
+            if isFreePosition(candidate,
+                              existingPositions: existingPositions,
+                              minDistance: minDistance) {
+                return candidate
+            }
+
+            angle += angleStep
+            if angle >= 2 * .pi {
+                angle -= 2 * .pi
+                radius += radiusStep
+            }
+
+            steps += 1
+        }
+
+        return clamped
+    }
+
+    // MARK: - Private Methods
+
+    /// 주어진 위치가 bounds 안에 있도록 xyz를 clamp
+    /// - Parameters:
+    ///   - position: 보정 대상이 되는 원본 위치
+    ///   - bounds: 오브젝트가 이동할 수 있는 허용 영역 범위
+    ///   - margin: 경계와의 최소 거리(여유 거리). 이 값만큼 안쪽으로 제한됨
+    /// - Returns: bounds 범위 안으로 보정된 안전한 위치 값
+    private func clampPosition(
+        _ position: SIMD3<Float>,
+        bounds: MovementBounds,
+        margin: Float
+    ) -> SIMD3<Float> {
+        var result = position
+
+        result.x = min(max(result.x, bounds.minX + margin), bounds.maxX - margin)
+        result.y = min(max(result.y, bounds.minY + margin), bounds.maxY - margin)
+        result.z = min(max(result.z, bounds.minZ + margin), bounds.maxZ - margin)
+
+        return result
+    }
+
+    /// 특정 위치가 기존 오브젝트들과 충분히 떨어져 있는지 검사
+    /// 기존 객체들과의 거리 중 하나라도 minDistance보다 작으면 겹친 것으로 간주
+    /// - Parameters:
+    ///   - position: 검사할 대상 위치
+    ///   - existingPositions: 현재 씬에 존재하는 모든 오브젝트의 위치 목록
+    ///   - minDistance: 유지해야 하는 최소 거리 값
+    /// - Returns: 모든 오브젝트와의 거리를 만족하면 true, 아니면 false
+    private func isFreePosition(
+        _ position: SIMD3<Float>,
+        existingPositions: [SIMD3<Float>],
+        minDistance: Float
+    ) -> Bool {
+        for existing in existingPositions {
+            if simd_distance(existing, position) < minDistance {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
@@ -29,6 +29,10 @@ struct SceneRealityView: View {
                 let newHeadAnchor = AnchorEntity(.head)
                 headAnchor = newHeadAnchor
                 
+                await MainActor.run {
+                    viewModel.rootEntity = rootEntity
+                }
+                
                 if config.useHeadAnchoredToolbar {
                     if let toolbar = attachments.entity(for: "headToolbar") {
                         // y: -0.3 = 시선보다 약간 아래

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImmersiveFeatures.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImmersiveFeatures.swift
@@ -128,12 +128,23 @@ extension SceneViewModel {
         
         let baseSize: Float = 0.5
         let width = baseSize * imageAttrs.scale
-
         let offset = width / 3
-        let newPosition = originalObject.position + SIMD3<Float>(offset, offset, 0.1)
+        
+        let basePosition = originalObject.position + SIMD3<Float>(offset, offset, 0.1)
+
+        // 2. 현재 씬에 있는 모든 오브젝트의 position 수집
+        let existingPositions = sceneObjects.map { $0.position }
+
+        // 3. PlacementPolicy로 "바운드 안 + 안 겹치는" 위치로 보정
+        //    (SceneViewModel 안에 placementPolicy를 프로퍼티로 가지고 있다고 가정)
+        let adjustedPosition = placementPolicy.adjustedPosition(
+            base: basePosition,
+            existingPositions: existingPositions
+        )
+        
         let duplicatedObject = SceneObject.createImage(
             assetId: originalObject.assetId,
-            position: newPosition,
+            position: adjustedPosition,
             isEditable: originalObject.isEditable,
             scale: imageAttrs.scale,
             rotation: imageAttrs.rotation,

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+SceneObject.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+SceneObject.swift
@@ -20,28 +20,24 @@ extension SceneViewModel {
     func addSceneObject(_ object: SceneObject, rootEntity: Entity? = nil) {
         guard var scene = appStateManager.selectedScene else { return }
         
-        // rootEntity가 제공된 경우 UseCase를 통해 객체 생성
-        if let rootEntity = rootEntity {
+        let parentEntity = rootEntity ?? self.rootEntity
+        if let parentEntity {
             do {
-                _ = try createObjectUseCase.execute(
+                var mutableScene = scene
+                let viewMode = userSpatialState.viewMode
+
+                let result = try createObjectUseCase.execute(
                     object: object,
-                    rootEntity: rootEntity,
-                    scene: &scene,
-                    viewMode: userSpatialState.viewMode
+                    rootEntity: parentEntity,
+                    scene: &mutableScene,
+                    viewMode: viewMode
                 )
-                appStateManager.selectScene(scene)
-            } catch CreateObjectError.assetNotFound {
-#if DEBUG
-                print("❌ SceneObject 생성 실패: 에셋을 찾을 수 없음 (assetId: \(object.assetId))")
-#endif
-            } catch CreateObjectError.entityCreationFailed {
-#if DEBUG
-                print("❌ Entity 생성 실패 (objectId: \(object.id))")
-#endif
+
+                appStateManager.selectScene(mutableScene)
+                selectedEntity = result.createdEntity
+
             } catch {
-#if DEBUG
-                print("❌ SceneObject 생성 실패: \(error)")
-#endif
+                print("❌ addSceneObject - Entity 생성 실패: \(error)")
             }
         } else {
             // rootEntity가 없는 경우 SceneObject만 추가 (Entity는 나중에 동기화)

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel.swift
@@ -18,6 +18,7 @@ final class SceneViewModel {
 
     // MARK: - Boundary Collision
     let boundaryCollisionManager: BoundaryCollisionManager
+    let placementPolicy: ObjectPlacementPolicy
 
     // MARK: - Initialization
     init(appStateManager: AppStateManager,
@@ -31,14 +32,15 @@ final class SceneViewModel {
         self.sceneObjectRepository = sceneObjectRepository
         self.assetRepository = assetRepository
         self.entityRepository = entityRepository
+        self.placementPolicy = ObjectPlacementPolicy()
         self.createObjectUseCase = CreateObjectUseCase(
             assetRepository: assetRepository,
             sceneObjectRepository: sceneObjectRepository,
-            entityRepository: entityRepository
+            entityRepository: entityRepository,
+            placementPolicy: placementPolicy
         )
         self.boundaryCollisionManager = BoundaryCollisionManager()
     }
-    
     
     // MARK: - State
     var selectedSceneModel: SceneModel?


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
- [x] 에셋 동일 위치에 생성 + 깜빡깜빡 (M) → 새로 생성한 애를 선택된 상태로 생성
- [x] 복제돼서 영역 밖에 생긴 에셋 선택 불가한 문제 (M)

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

https://github.com/user-attachments/assets/c2b08dd0-760e-4f4c-8eec-049b62482de7



## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
### 1. `ObjectPlacementPolicy.swift` 추가

```swift
    // MARK: - Public Methods

    /// 새 오브젝트의 최종 배치 위치 계산
    /// - Parameters:
    ///   - base: 사용자가 의도한 기본 위치 (예: 원본 오브젝트 근처, 카메라 앞 등)
    ///   - existingPositions: 현재 씬에 존재하는 모든 SceneObject의 position 배열
    /// - Returns: MovementBounds 안에 있으며, 기존 오브젝트와 최소 거리를 만족하려고 시도한 최종 위치
    ///
    /// 동작 순서:
    /// 1. base 위치를 bounds 안으로 clamp
    /// 2. 기존 오브젝트들과 minDistance 이상 떨어져 있다면 그대로 사용
    /// 3. 겹친다면, base 주변을 원형/나선형으로 돌며 비어 있는 위치를 탐색
    /// 4. 끝까지 못 찾으면 clamp된 위치를 그대로 반환 (최악의 fallback)
    func adjustedPosition(
        base: SIMD3<Float>,
        existingPositions: [SIMD3<Float>]
    ) -> SIMD3<Float> {
        let clamped = clampPosition(base, bounds: movementBounds, margin: minDistance)

        if isFreePosition(clamped,
                          existingPositions: existingPositions,
                          minDistance: minDistance) {
            return clamped
        }

        let maxRadiusX = max(movementBounds.maxX - clamped.x,
                             clamped.x - movementBounds.minX)
        let maxRadiusZ = max(movementBounds.maxZ - clamped.z,
                             clamped.z - movementBounds.minZ)
        let maxRadius = min(maxRadiusX, maxRadiusZ)

        let angleStep: Float = .pi / 12
        let radiusStep: Float = minDistance * 0.8

        var angle: Float = 0
        var radius: Float = minDistance

        var steps = 0
        let maxSteps = 2000

        while radius <= maxRadius && steps < maxSteps {
            let offset = SIMD3<Float>(
                x: cos(angle) * radius,
                y: 0,
                z: sin(angle) * radius
            )

            var candidate = clamped + offset
            candidate = clampPosition(candidate,
                                      bounds: movementBounds,
                                      margin: minDistance)

            if isFreePosition(candidate,
                              existingPositions: existingPositions,
                              minDistance: minDistance) {
                return candidate
            }

            angle += angleStep
            if angle >= 2 * .pi {
                angle -= 2 * .pi
                radius += radiusStep
            }

            steps += 1
        }

        return clamped
    }
```
1. clamped 계산
- base를 그대로 쓰지 않고, movementBounds + minDistance를 고려해서 안전한 내부 위치로 먼저 clamp. 경계에서 살짝 안쪽으로 들어오게 해서 벽과도 겹치지 않게함

2. case 1 – 이미 비어 있으면 그대로 사용
- isFreePosition(clamped, ...) == true → 주변에 다른 애 없으면 그냥 clamped 반환

3. case 2 – 겹치면 “나선형 검색” 시작
- maxRadiusX, maxRadiusZ 로 이론적으로 움직일 수 있는 최대 반경 계산
- maxRadius = min(maxRadiusX, maxRadiusZ) → 사각형 bounds에서 가능한 최대 원 반경
- while 루프에서

> - angle는 angleStep씩 증가 → 원을 돌며 탐색
> - 한 바퀴(2π) 돌고 나면 → radius를 radiusStep 만큼 증가 → 조금 더 바깥 원을 탐색
> - 매번 candidate를 clampPosition으로 다시 한 번 bounds 안으로 정리
> - 그 위치가 비어 있으면 → 바로 return (가장 가까운 빈자리)

5. 안전장치 – 무한 루프 방지
- steps < maxSteps(2000) 조건으로 안전하게 브레이크
- 정말 꽉 찬 경우엔 마지막에 return clamped (원래 clamped 값)

```swift
    // MARK: - Private Methods

    /// 주어진 위치가 bounds 안에 있도록 xyz를 clamp
    /// - Parameters:
    ///   - position: 보정 대상이 되는 원본 위치
    ///   - bounds: 오브젝트가 이동할 수 있는 허용 영역 범위
    ///   - margin: 경계와의 최소 거리(여유 거리). 이 값만큼 안쪽으로 제한됨
    /// - Returns: bounds 범위 안으로 보정된 안전한 위치 값
    private func clampPosition(
        _ position: SIMD3<Float>,
        bounds: MovementBounds,
        margin: Float
    ) -> SIMD3<Float> {
        var result = position

        result.x = min(max(result.x, bounds.minX + margin), bounds.maxX - margin)
        result.y = min(max(result.y, bounds.minY + margin), bounds.maxY - margin)
        result.z = min(max(result.z, bounds.minZ + margin), bounds.maxZ - margin)

        return result
    }
```
MovementBounds + margin을 이용해서
- minX + margin ~ maxX - margin
- minY + margin ~ maxY - margin
- minZ + margin ~ maxZ - margin
- 이 안으로만 값이 들어오도록 강제
=> 바운더리 밖으로 튀어나가려는 값을 안전 영역으로 끌어오는 역할

```swift
    /// 특정 위치가 기존 오브젝트들과 충분히 떨어져 있는지 검사
    /// 기존 객체들과의 거리 중 하나라도 minDistance보다 작으면 겹친 것으로 간주
    /// - Parameters:
    ///   - position: 검사할 대상 위치
    ///   - existingPositions: 현재 씬에 존재하는 모든 오브젝트의 위치 목록
    ///   - minDistance: 유지해야 하는 최소 거리 값
    /// - Returns: 모든 오브젝트와의 거리를 만족하면 true, 아니면 false
    private func isFreePosition(
        _ position: SIMD3<Float>,
        existingPositions: [SIMD3<Float>],
        minDistance: Float
    ) -> Bool {
        for existing in existingPositions {
            if simd_distance(existing, position) < minDistance {
                return false
            }
        }
        return true
    }
}
```
- simd_distance(existing, position)을 모두 돌면서 
- 하나라도 minDistance보다 가까우면 → 겹치는 위치 → false
- 전부 거리 조건을 만족하면 → 안전한 자리 → true

---

### 2. CreateObjectUseCase 안에서 ObjectPlacementPolicy 로 초기 배치 위치 보정까지 한 번에 처리
```swift
// CreateObjectUseCase.swift

struct CreateObjectUseCase {
    let assetRepository: AssetRepositoryInterface
    let sceneObjectRepository: SceneObjectRepositoryInterface
    let entityRepository: EntityRepositoryInterface
    let placementPolicy: ObjectPlacementPolicy

    @MainActor
    func execute(
        object: SceneObject,
        rootEntity: Entity,
        scene: inout SceneModel,
        viewMode: Bool
    ) throws -> CreateObjectResult {
        var object = object

        //  1. 기존 오브젝트들의 position 모음
        let existingPositions = scene.sceneObjects.map { $0.position }

        //  2. 위치 정책 적용 (bounds 안 + 안 겹치게)
        object.position = placementPolicy.adjustedPosition(
            base: object.position,
            existingPositions: existingPositions
        )

        // 3. Asset 조회
        guard let asset = assetRepository.asset(withId: object.assetId) else {
            throw CreateObjectError.assetNotFound
        }

        // 4. SceneObject 추가
        sceneObjectRepository.addObject(object, to: &scene)

        // 5. Entity 생성
        guard let entity = entityRepository.createEntity(
            from: object,
            asset: asset,
            rootEntity: rootEntity,
            viewMode: viewMode
        ) else {
            throw CreateObjectError.entityCreationFailed
        }

        return CreateObjectResult(
            createdObject: object,
            createdEntity: entity
        )
    }
}
```
---

### 3. `SceneViewModel.addSceneObject` – 새로 만든 엔티티를 선택 상태로

```swift
// SceneViewModel+SceneObject.swift

func addSceneObject(_ object: SceneObject, rootEntity: Entity? = nil) {
    guard var scene = appStateManager.selectedScene else { return }

    if let rootEntity = rootEntity {
        // UseCase 통해 SceneObject + Entity 동시 생성
        do {
            let result = try createObjectUseCase.execute(
                object: object,
                rootEntity: rootEntity,
                scene: &scene,
                viewMode: userSpatialState.viewMode
            )

            // 변경된 Scene 반영
            appStateManager.selectScene(scene)

            // 새로 생성된 Entity를 바로 선택
            selectedEntity = result.createdEntity

        } catch {
            #if DEBUG
            print("❌ addSceneObject execute 실패: \(error)")
            #endif
        }

    } else {
        // rootEntity가 없는 경우: SceneObject만 추가 (Library window 등)
        sceneObjectRepository.addObject(object, to: &scene)
        appStateManager.selectScene(scene)
    }

    saveScene()
}
```
라이브러리/에디터/복제/다른 진입점 등에서 새로 생성하는 경우
  → `rootEntity`가 있는 쪽은 모두 `ObjectPlacementPolicy`로 위치 보정 + `selectedEntity = createdEntity` 로 곧바로 선택 상태

---

### 4. `SceneViewModel.duplicateObject` – 동일 경로 사용

```swift
// SceneViewModel+ImmersiveCRUD.swift

func duplicateObject(rootEntity: Entity) -> SceneObject? {
    guard let selectedEntity = selectedEntity,
          let objectId = UUID(uuidString: selectedEntity.name),
          let originalObject = sceneObjects.first(where: { $0.id == objectId }),
          case .image(let imageAttrs) = originalObject.attributes else {
        return nil
    }

    let baseSize: Float = 0.5
    let width = baseSize * imageAttrs.scale
    let offset = width / 3

    let newPosition = originalObject.position + SIMD3<Float>(offset, offset, 0.1)

    let duplicatedObject = SceneObject.createImage(
        assetId: originalObject.assetId,
        position: newPosition,
        isEditable: originalObject.isEditable,
        scale: imageAttrs.scale,
        rotation: imageAttrs.rotation,
        crop: imageAttrs.crop,
        lock: imageAttrs.lock
    )

    //  addSceneObject가 ObjectPlacementPolicy + selectedEntity 설정까지 처리
    addSceneObject(duplicatedObject, rootEntity: rootEntity)

    return duplicatedObject
}
```
복제본이 MovementBounds 밖으로 튀어나갈만한 위치여도
→ ObjectPlacementPolicy가 다시 bounds 내부의 빈 공간으로 재배치

addSceneObject가 selectedEntity를 새 엔티티로 바꿔주기 때문에
→ 항상 “복제된 오브젝트”가 선택 상태가 됨
→ 영역 밖으로 떠밀려도 “복제본”을 기준으로 깜빡임/바운딩 박스/툴바 동작
