### PR TITLE
Feat - 이미지 크롭 취소/완료 버튼 기능 구현

### DIFF
--- a/Glayer/Sources/Common/Enum/CapsuleTextButtonEnum.swift
+++ b/Glayer/Sources/Common/Enum/CapsuleTextButtonEnum.swift
@@ -10,49 +10,63 @@ import SwiftUI
 enum CapsuleTextButtonEnum {
     case imageEditorView
     case dropDockOverlayView
-    
+    case cropCancel
+    case cropComplete
+
     var font: Font {
         switch self {
         case .imageEditorView:
             return .system(size: 17, weight: .medium)
         case .dropDockOverlayView:
             return .system(size: 19, weight: .medium)
+        case .cropCancel, .cropComplete:
+            return .system(size: 17, weight: .medium)
         }
     }
-    
+
     var fontColor: Color {
         switch self {
         case .imageEditorView:
             return .primary
         case .dropDockOverlayView:
             return .primary
+        case .cropCancel:
+            return .red
+        case .cropComplete:
+            return .white
         }
     }
-    
+
     var verticalPadding: CGFloat {
         switch self {
         case .imageEditorView:
             return 11
         case .dropDockOverlayView:
             return 6.5
+        case .cropCancel, .cropComplete:
+            return 17.5
         }
     }
-    
+
     var horizontalPadding: CGFloat {
         switch self {
         case .imageEditorView:
             return 16
         case .dropDockOverlayView:
             return 26
+        case .cropCancel, .cropComplete:
+            return 24
         }
     }
-    
+
     var background: AnyShapeStyle {
         switch self {
         case .imageEditorView:
             return AnyShapeStyle(.ultraThinMaterial)
         case .dropDockOverlayView:
             return AnyShapeStyle(.black.opacity(0.26))
+        case .cropCancel, .cropComplete:
+            return AnyShapeStyle(.ultraThinMaterial)
         }
     }
 }

--- a/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
+++ b/Glayer/Sources/Helpers/Entity/Attachment/AttachmentPositioner.swift
@@ -8,6 +8,7 @@ enum AttachmentPositioner {
     /// - Parameters:
     ///   - attachment: 위치를 설정할 Attachment Entity
     ///   - parent: Attachment가 첨부될 부모 Entity
+    ///   - isVolumeMode: Volume 모드 여부
     static func positionAtTop(_ attachment: Entity, relativeTo parent: Entity, isVolumeMode: Bool) {
         let objectBounds = parent.visualBounds(relativeTo: parent)
         let attachmentBounds = attachment.visualBounds(relativeTo: nil)
@@ -52,7 +53,35 @@ enum AttachmentPositioner {
         let yOffset: Float = baseLine + attachmentHalfHeight + margin // 이미지 최상단 + 어태치 먼트 바닥 + 마진(사진 마진/4 - 라인값/2)
         attachment.position = SIMD3<Float>(0, yOffset, 0.01)
     }
-    
+
+    /// CropAttachment를 이미지 상단에 위치시킴
+    /// - Parameters:
+    ///   - attachment: 위치를 설정할 CropControl Attachment Entity
+    ///   - parent: Attachment가 첨부될 부모 Entity (이미지 엔티티)
+    ///   - isVolumeMode: Volume 모드 여부
+    static func positionAboveCrop(_ attachment: Entity, relativeTo parent: Entity, isVolumeMode: Bool) {
+        guard let imagePlane = parent.findEntity(named: "imagePlane") else { return }
+
+        let planeBounds = imagePlane.visualBounds(relativeTo: parent)
+        let attachmentBounds = attachment.visualBounds(relativeTo: nil)
+        let parentScale = parent.scale(relativeTo: nil)
+
+        // planeMargin과 glowCorrection 계산
+        let planeMargin = min(planeBounds.extents.x, planeBounds.extents.y)
+
+        let width = planeBounds.extents.x
+        let height = planeBounds.extents.y
+        let glowCorrection = EntityBoundBoxApplier.calculateGlowCorrection(width: width, height: height)
+
+        // imagePlane 상단에 위치
+        let imagePlaneTop = planeBounds.max.y
+        let attachmentHalfHeight = (attachmentBounds.extents.y / 2) / parentScale.y
+        let margin = planeMargin/4 - glowCorrection.height/2
+
+        let yOffset = imagePlaneTop + attachmentHalfHeight + margin
+        attachment.position = SIMD3<Float>(0, yOffset, 0.01)
+    }
+
     /// 중앙 위치로 Attachment 설정
     /// - Parameters:
     ///   - attachment: 위치를 설정할 Attachment Entity

--- a/Glayer/Sources/Models/Scene/CropTriggerState.swift
+++ b/Glayer/Sources/Models/Scene/CropTriggerState.swift
@@ -1,0 +1,20 @@
+//
+//  CropTriggerState.swift
+//  Glayer
+//
+//  Created by PenguinLand on 1/9/26.
+//
+
+import Foundation
+import Observation
+
+/// CropAttachment의 외부 트리거 상태를 관리하는 Observable 객체
+///
+/// Crop UI와 Control UI 간의 상태 동기화를 위해 사용됨
+/// - `shouldComplete`: 크롭 완료 트리거
+/// - `shouldCancel`: 크롭 취소 트리거
+@Observable
+class CropTriggerState {
+    var shouldComplete: Bool = false
+    var shouldCancel: Bool = false
+}

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/Crop/CropAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/Crop/CropAttachment.swift
@@ -7,6 +7,14 @@
 
 import SwiftUI
 import RealityKit
+import Observation
+
+/// CropAttachment의 외부 트리거 상태를 관리하는 Observable 객체
+@Observable
+class CropTriggerState {
+    var shouldComplete: Bool = false
+    var shouldCancel: Bool = false
+}
 
 struct CropAttachment: View {
     
@@ -17,11 +25,12 @@ struct CropAttachment: View {
     let scaleX: CGFloat?
     let scaleY: CGFloat?
     let onDone: (UVRect) -> Void
-    
+
     @State private var cropRect: CGRect = .zero
     @State private var viewSize: CGSize = .zero
     @State private var imageFrame: CGRect = .zero
     @State private var didComplete = false
+    var triggerState: CropTriggerState
     
     /// 실제로 화면에 깔릴 이미지
     /// - initialUV가 전체(0,0,1,1)이면 원본 그대로
@@ -94,8 +103,10 @@ struct CropAttachment: View {
         .frame(width: 1000)
         .aspectRatio(displayImage.size, contentMode: .fit)
         .background(.clear)
-        .onDisappear {
-            if !didComplete { complete() }
+        .onChange(of: triggerState.shouldComplete) { oldValue, newValue in
+            if newValue && !didComplete {
+                complete()
+            }
         }
     }
     
@@ -148,6 +159,21 @@ struct CropAttachment: View {
         let finalUV = initialUV.clamped().composed(with: innerUV).clamped()
         
         onDone(finalUV)
+    }
+
+    /// 현재 크롭 상태를 UVRect로 변환하여 반환 (완료하지 않고 조회만)
+    /// CropControlAttachment의 완료 버튼에서 호출됨
+    func getCurrentUV() -> UVRect {
+        guard viewSize != .zero else {
+            return initialUV.clamped()
+        }
+
+        let mapper = AspectFitMapper(
+            viewSize: viewSize,
+            imageSize: displayImage.size
+        )
+        let innerUV = mapper.viewRectToUV(cropRect).clamped()
+        return initialUV.clamped().composed(with: innerUV).clamped()
     }
 }
 

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/Crop/CropAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/Crop/CropAttachment.swift
@@ -7,14 +7,6 @@
 
 import SwiftUI
 import RealityKit
-import Observation
-
-/// CropAttachment의 외부 트리거 상태를 관리하는 Observable 객체
-@Observable
-class CropTriggerState {
-    var shouldComplete: Bool = false
-    var shouldCancel: Bool = false
-}
 
 struct CropAttachment: View {
     

--- a/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/Crop/CropControlAttachment.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/Attachment/Crop/CropControlAttachment.swift
@@ -1,0 +1,47 @@
+//
+//  CropControlAttachment.swift
+//  Glayer
+//
+//  Created by PenguinLand on 01/05/26.
+//
+
+import SwiftUI
+
+/// 이미지 크롭 중에 표시되는 취소/완료 버튼 UI
+/// CropAttachment 상단에 배치되어 사용자가 명시적으로 크롭을 완료하거나 취소할 수 있도록 함
+struct CropControlAttachment: View {
+
+    // MARK: - Properties
+
+    let onCancel: () -> Void
+    let onComplete: () -> Void
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: 20) {
+            // 취소 버튼
+            CapsuleTextButton(
+                title: "취소",
+                type: .cropCancel,
+                action: onCancel
+            )
+            .glassBackgroundEffect()
+
+            // 완료 버튼
+            CapsuleTextButton(
+                title: "완료",
+                type: .cropComplete,
+                action: onComplete
+            )
+            .glassBackgroundEffect()
+        }
+    }
+}
+
+#Preview {
+    CropControlAttachment(
+        onCancel: { print("취소") },
+        onComplete: { print("완료") }
+    )
+}

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImageCrop.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImageCrop.swift
@@ -26,7 +26,10 @@ extension SceneViewModel {
     ///   - objectId: 크롭 상태를 갱신할 `SceneObject`의 식별자(UUID)
     func startImageCrop(for entity: ModelEntity, objectId: UUID) {
         attachmentTimer?.cancel()
-        
+
+        // EditBarAttachment UI 제거
+        removeAttachment(from: entity)
+
         guard
             let obj = sceneObjects.first(where: { $0.id == objectId }),
             case .image(let attrs) = obj.attributes,
@@ -39,34 +42,68 @@ extension SceneViewModel {
         let cropAttachment = Entity()
         cropAttachment.name = "cropAttachment"
         
+        // Crop 트리거 상태 생성
+        let triggerState = CropTriggerState()
+
         let onDone: (UVRect) -> Void = { [weak self] newUV in
             guard let self else { return }
-            self.updateObjectCrop(id: objectId, uv: newUV)
-            self.setImagePlaneHidden(false, on: entity)
+            self.completeCrop(for: entity, objectId: objectId, uv: newUV)
         }
-        
+
         let baseView = CropAttachment(
             image: uiImage,
             initialUV: initialUV,
             scaleX: 1.0,
             scaleY: 1.0,
-            onDone: onDone
+            onDone: onDone,
+            triggerState: triggerState
         )
         cropAttachment.components.set(ViewAttachmentComponent(rootView: baseView))
         entity.addChild(cropAttachment)
-        
+
         let (scaleX, scaleY) = EntityAttachmentSizeDeterminator.scaleAttachmentToBound(cropAttachment, on: entity)
-        
+
         let scaledView = CropAttachment(
             image: uiImage,
             initialUV: initialUV,
             scaleX: scaleX,
             scaleY: scaleY,
-            onDone: onDone
+            onDone: onDone,
+            triggerState: triggerState
         )
         EntityBoundBoxApplier.removeBoundBox(from: entity)
         cropAttachment.components.set(ViewAttachmentComponent(rootView: scaledView))
         setImagePlaneHidden(true, on: entity)
+
+        // Crop 조작 버튼 추가
+        let cropControlEntity = Entity()
+        cropControlEntity.name = "cropControlAttachment"
+
+        let controlView = CropControlAttachment(
+            onCancel: { [weak self] in
+                guard let self else { return }
+                self.cancelCrop(for: entity)
+            },
+            onComplete: {
+                triggerState.shouldComplete = true
+            }
+        )
+
+        cropControlEntity.components.set(ViewAttachmentComponent(rootView: controlView))
+        cropControlEntity.components.set(BillboardComponent()) // Always face user
+
+        let headPosition = userSpatialState.sceneHeadAnchor.position
+        let finalScale = EntityAttachmentSizeDeterminator.calculateFinalScale(
+            headPosition: headPosition,
+            entity: entity,
+            isVolumeMode: appStateManager.appState.isVolumeOpen
+        )
+        cropControlEntity.scale = finalScale
+
+        entity.addChild(cropControlEntity)
+
+        // Position above crop UI
+        AttachmentPositioner.positionAboveCrop(cropControlEntity, relativeTo: entity, isVolumeMode: appStateManager.appState.isVolumeOpen)
     }
     
     /// 선택된 이미지 객체의 크롭 정보(UVRect)를 갱신하고, 장면(Scene) 상태 및 실제 RealityKit 엔티티 양쪽 모두에 반영
@@ -124,7 +161,43 @@ extension SceneViewModel {
         entity.findEntity(named: "cropAttachment")?.removeFromParent()
         setImagePlaneHidden(false, on: entity)
     }
-    
+
+    /// 엔티티에 붙어있는 크롭 컨트롤 UI(CropControlAttachment)를 제거
+    /// - Parameter entity: 크롭 컨트롤 UI가 부착되어 있는 대상 `ModelEntity`
+    func removeCropControlAttachment(from entity: ModelEntity) {
+        entity.findEntity(named: "cropControlAttachment")?.removeFromParent()
+    }
+
+    /// 크롭을 완료하고 새로운 크롭 영역을 적용
+    /// - Parameters:
+    ///   - entity: 크롭 대상 이미지 엔티티
+    ///   - objectId: 크롭할 SceneObject의 ID
+    ///   - uv: 적용할 크롭 영역 (UVRect)
+    func completeCrop(for entity: ModelEntity, objectId: UUID, uv: UVRect) {
+        // 크롭 적용
+        updateObjectCrop(id: objectId, uv: uv)
+
+        // 크롭 UI 제거
+        removeCropAttachment(from: entity)
+        removeCropControlAttachment(from: entity)
+
+        // Editbar 재활성화 (with timer)
+        let headPosition = userSpatialState.sceneHeadAnchor.position
+        addAttachmentAndStartTimer(for: entity, headPosition: headPosition)
+    }
+
+    /// 크롭을 취소하고 원래 상태로 복원
+    /// - Parameter entity: 크롭 대상 이미지 엔티티
+    func cancelCrop(for entity: ModelEntity) {
+        // 크롭 UI 제거 및 변경사항 미적용
+        removeCropAttachment(from: entity)
+        removeCropControlAttachment(from: entity)
+
+        // Editbar 재활성화 (with timer)
+        let headPosition = userSpatialState.sceneHeadAnchor.position
+        addAttachmentAndStartTimer(for: entity, headPosition: headPosition)
+    }
+
     func setImagePlaneHidden(_ hidden: Bool, on entity: ModelEntity) {
         guard let imagePlane = entity.findEntity(named: "imagePlane") as? ModelEntity else {
             return


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
이미지 크롭 중 사용자가 크롭을 완료하거나 취소할 수 있도록 취소/완료 버튼 추가.

### **구현 내용**
**1. CropControlAttachment UI 구현**
 - 크롭 UI 상단에 표시되는 취소/완료 버튼 UI
 - 기존 CapsuleTextButton 컴포넌트 재사용

**2. EditBarAttachment 숨김 처리**
 - 크롭 모드 진입 시 EditBarAttachment 제거.
 - 크롭 완료/취소 시 EditBarAttachment 자동 복원

**3. 크롭 완료 로직 변경**
 - 기존: `.onDisappear`으로 자동 완료
 - 변경 후: 버튼 클릭에 따른 `.onChange로` 완료/취소
 ```swift
 .onChange(of: triggerState.shouldComplete) { oldValue, newValue in
            if newValue && !didComplete {
                complete()
            }
        }
 ```

**4. @Observable 기반 상태 관리로 Crop UI 동기화**
```swift
/// CropTriggerState.swift
@Observable
class CropTriggerState {
    var shouldComplete: Bool = false
    var shouldCancel: Bool = false
}
```

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
![Simulator Screen Recording - Apple Vision Pro - 2026-01-09 at 11 25 16](https://github.com/user-attachments/assets/591a71f7-9480-410e-85f2-83779385db00)



## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
