### PR TITLE
Fix - Floor 및 Crop 관련 이슈 수정

### DIFF
--- a/Glayer/Sources/Helpers/Entity/Environment/ObjectPlacementPolicy.swift
+++ b/Glayer/Sources/Helpers/Entity/Environment/ObjectPlacementPolicy.swift
@@ -23,7 +23,7 @@ struct ObjectPlacementPolicy {
     ///   - minDistance: 다른 오브젝트와의 최소 거리
     init(
            movementBounds: MovementBounds? = nil,
-           minDistance: Float = 0.03
+           minDistance: Float = 0.08
     ) {
         self.movementBounds = movementBounds ?? SceneConstants.defaultMovementBounds
         self.minDistance = minDistance

--- a/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/View/SceneRealityView.swift
@@ -110,6 +110,8 @@ struct SceneRealityView: View {
 
         // Volume Window일 때
         if appStateManager.appState.isVolumeOpen {
+            // Floor 엔티티는 모드 간 재사용되므로 Immersive 전용 배경이 남아있지 않도록 정리
+            viewModel.removeImmersiveBackgroundIfNeeded(from: floor)
             
             let humanScaleEntity = await HumanScaleEntity.create()
             floor.addChild(humanScaleEntity)
@@ -225,4 +227,3 @@ struct SceneRealityView: View {
         }
     }
 }
-

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+AttachmentManagement.swift
@@ -120,6 +120,7 @@ extension SceneViewModel {
     func removeAttachment(from entity: ModelEntity) {
         // 크롭 어태치먼트 먼저 제거
         removeCropAttachment(from: entity)
+        removeCropControlAttachment(from: entity)
         
         // boundBox 제거
         EntityBoundBoxApplier.removeBoundBox(from: entity)

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+EditBarAttachement.swift
@@ -9,6 +9,12 @@ extension SceneViewModel {
     
     /// Entity에 attachment를 추가하고 타이머 시작
     func addAttachmentAndStartTimer(for entity: ModelEntity, headPosition: SIMD3<Float>) {
+        // 크롭 진행 중(취소/완료 버튼 노출 포함)에는 EditBar를 다시 붙이지 않음
+        let isCropUIVisible =
+            entity.findEntity(named: "cropAttachment") != nil ||
+            entity.findEntity(named: "cropControlAttachment") != nil
+        guard !isCropUIVisible else { return }
+
         guard let objectId = UUID(uuidString: entity.name),
               let sceneObject = sceneObjects.first(where: { $0.id == objectId })
         else { return }

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImmersiveFeatures.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel+ImmersiveFeatures.swift
@@ -161,13 +161,32 @@ extension SceneViewModel {
 
     // MARK: - Immersive 배경 관리
 
+    /// floor에 붙어있는 Immersive 배경 엔티티를 정리
+    /// - Note: floor 엔티티가 모드 전환 간 재사용되므로 Volume 복귀 전에 반드시 정리 필요
+    func removeImmersiveBackgroundIfNeeded(from floor: Entity) {
+        // 추적 중인 배경 참조 제거
+        if let currentImmersiveBackground {
+            currentImmersiveBackground.removeFromParent()
+            self.currentImmersiveBackground = nil
+        }
+
+        // 참조가 유실된 경우를 대비해 이름 기반으로도 정리
+        floor.children
+            .filter { $0.name == "immersiveBackground" }
+            .forEach { $0.removeFromParent() }
+    }
+
     /// Immersive 배경을 현재 시간대에 맞게 로드
     /// - Parameter floor: 배경을 추가할 floor Entity
     func loadImmersiveBackground(on floor: Entity) async {
+        // 중복 로드를 막기 위해 기존 배경을 먼저 정리
+        removeImmersiveBackgroundIfNeeded(from: floor)
+
         let immersiveTime = spacialEnvironment.immersiveTime
         let backgroundName = immersiveTime == .day ? "Immersive" : "ImmersiveNight"
 
         if let immersiveBackground = try? await Entity(named: backgroundName, in: RealityKitContent.realityKitContentBundle) {
+            immersiveBackground.name = "immersiveBackground"
             floor.addChild(immersiveBackground)
             currentImmersiveBackground = immersiveBackground
         }

--- a/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel.swift
+++ b/Glayer/Sources/Presentations/SceneRealityView/ViewModel/SceneViewModel.swift
@@ -146,6 +146,8 @@ final class SceneViewModel {
     func reset() {
         entityRepository.clearAllCaches()
         selectedEntity = nil
+        appliedFloorImageURL = nil
+        currentImmersiveBackground = nil
         stopJoystickMovement()
         boundaryCollisionManager.removeBoundaryWalls()
     }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
크롭 진행 중 취소/완료 버튼이 노출될 때 EditBarAttachment가 다시 나타나는 이슈를 수정.
floor 관련 이슈(Immersive → Volume 복귀 시 배경 잔존으로 floor가 비정상적으로 보이는 현상) 수정.

- addAttachmentAndStartTimer에서 cropAttachment 또는 cropControlAttachment가 존재하면 EditBar 재부착 차단
- removeAttachment에서 cropControlAttachment도 함께 제거하도록 수정
- floor 엔티티 재사용 시 Immersive 배경이 남지 않도록 정리 메서드를 추가
- Volume 진입 시 Immersive 배경을 제거하도록 연결
- Immersive 배경 로드 시 기존 배경을 먼저 제거해 중복 child 누적 방지
- reset() 시 appliedFloorImageURL, currentImmersiveBackground 초기화 추가

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
